### PR TITLE
Make Makefile and dotfiles cross-platform (Linux support)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,7 +3,7 @@ tap "metalbear-co/mirrord"
 brew "git"
 brew "emacs"
 brew "gnupg"
-brew "pinentry-mac"
+brew "pinentry-mac" # macOS only
 brew "php@8.4", link: true
 brew "mycli"
 brew "tmux"
@@ -15,6 +15,7 @@ brew "mise"
 brew "uv"
 brew "gh"
 brew "github-mcp-server"
+# macOS only
 cask "docker-desktop"
 cask "gcloud-cli"
 cask "vagrant"

--- a/Brewfile
+++ b/Brewfile
@@ -3,7 +3,6 @@ tap "metalbear-co/mirrord"
 brew "git"
 brew "emacs"
 brew "gnupg"
-brew "pinentry-mac" # macOS only
 brew "php@8.4", link: true
 brew "mycli"
 brew "tmux"
@@ -15,11 +14,5 @@ brew "mise"
 brew "uv"
 brew "gh"
 brew "github-mcp-server"
-# macOS only
-cask "docker-desktop"
-cask "gcloud-cli"
-cask "vagrant"
-cask "vagrant-vmware-utility"
-cask "virtualbox"
 
 uv "claude-monitor"

--- a/Brewfile.darwin
+++ b/Brewfile.darwin
@@ -1,0 +1,7 @@
+brew "pinentry-mac"
+
+cask "docker-desktop"
+cask "gcloud-cli"
+cask "vagrant"
+cask "vagrant-vmware-utility"
+cask "virtualbox"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
 PWD=$(shell pwd)
+UNAME := $(shell uname)
 
-.PHONY: all brew_bundle bin ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_zim zim ln_aqua clean_aqua clean_emacs clean cleanall
+.PHONY: all install_packages brew_bundle bin ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_zim zim ln_aqua clean_aqua clean_emacs clean cleanall
 
-all: brew_bundle ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_zim
+all: install_packages ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_zim
+
+install_packages:
+ifeq ($(UNAME), Darwin)
+	brew bundle install --file=$(PWD)/Brewfile
+else
+	@echo "Skipping brew_bundle on Linux"
+endif
 
 brew_bundle: Brewfile
 	brew bundle install --file=$(PWD)/Brewfile

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ all: install_packages ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_z
 install_packages:
 ifeq ($(UNAME), Darwin)
 	brew bundle install --file=$(PWD)/Brewfile
+	brew bundle install --file=$(PWD)/Brewfile.darwin
 else
-	@echo "Skipping brew_bundle on Linux"
+	brew bundle install --file=$(PWD)/Brewfile
 endif
 
 brew_bundle: Brewfile

--- a/bin/github-mcp-server
+++ b/bin/github-mcp-server
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 export GITHUB_PERSONAL_ACCESS_TOKEN="$(gh auth token)"
-exec /opt/homebrew/bin/github-mcp-server stdio
+exec github-mcp-server stdio

--- a/gitconfig
+++ b/gitconfig
@@ -37,7 +37,7 @@
 [rebase]
 	autosquash = true
 [gpg]
-	program = /opt/homebrew/bin/gpg
+	program = gpg
 [commit]
 	gpgsign = true
 [init]

--- a/tmux.conf
+++ b/tmux.conf
@@ -20,7 +20,9 @@ set -g update-environment LC_CTYPE
 set -g history-limit 10000
 
 # copy & paste
-bind -T copy-mode Enter send-keys -X copy-pipe-and-cancel "pbcopy"
+if-shell "uname | grep -q Darwin" \
+  "bind -T copy-mode Enter send-keys -X copy-pipe-and-cancel 'pbcopy'" \
+  "bind -T copy-mode Enter send-keys -X copy-pipe-and-cancel 'xclip -in -selection clipboard'"
 bind C-y paste-buffer
 
 # split pane


### PR DESCRIPTION
## What

- Makefile に OS 判定を追加し、macOS では `Brewfile` + `Brewfile.darwin`、Linux では `Brewfile` のみを読み込む `install_packages` ターゲットを追加
- `Brewfile` を共通パッケージのみに整理し、macOS 専用パッケージ（`pinentry-mac`、各種 cask）を `Brewfile.darwin` に分離
- `gitconfig` の `gpg.program` を絶対パスからコマンド名 `gpg` に変更
- `tmux.conf` の copy-mode バインドを OS 判定で `pbcopy`（macOS）/ `xclip`（Linux）に切り替え
- `bin/github-mcp-server` の絶対パスを PATH 解決に変更

## Why

dotfilesがmacOS専用になっており、Linuxでは`make`が失敗していた。詳細は#1参照。

Closes #1

## Test plan
