### PR TITLE
Use stamp files to skip brew bundle when Brewfile is unchanged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ php/vendor
 # Claude Code
 .claude/settings.json
 .claude/settings.local.json
+
+# Make stamp files
+.make/

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,23 @@
 PWD=$(shell pwd)
 UNAME := $(shell uname)
 
-.PHONY: all install_packages brew_bundle bin ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_zim zim ln_aqua clean_aqua clean_emacs clean cleanall
+.PHONY: all brew_bundle bin ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_zim zim ln_aqua clean_aqua clean_emacs clean cleanall
 
-all: install_packages ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_zim
+all: .make/install_packages ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_zim
 
-install_packages:
+ifeq ($(UNAME), Darwin)
+.make/install_packages: Brewfile Brewfile.darwin
+else
+.make/install_packages: Brewfile
+endif
+	@mkdir -p .make
 ifeq ($(UNAME), Darwin)
 	brew bundle install --file=$(PWD)/Brewfile
 	brew bundle install --file=$(PWD)/Brewfile.darwin
 else
 	brew bundle install --file=$(PWD)/Brewfile
 endif
+	@touch $@
 
 brew_bundle: Brewfile
 	brew bundle install --file=$(PWD)/Brewfile


### PR DESCRIPTION
## What

- `install_packages` ターゲットをスタンプファイルベース（`.make/install_packages`）に変更し、Brewfile が変更されていない場合は `brew bundle install` をスキップするようにした
- macOS では `Brewfile` または `Brewfile.darwin` が変更された時のみ実行、Linux では `Brewfile` のみを依存とする
- `.make/` を `.gitignore` に追加

## Why

`.PHONY`ターゲットのせいで、`make all`を実行するたびに`brew bundle install`を含む全コマンドが無駄に走っていた。詳細は#3参照。

Fixes #3

## Test plan
