### PR TITLE
Automate ssh-agent startup and ssh-add

### DIFF
--- a/zsh/ssh/init.sh
+++ b/zsh/ssh/init.sh
@@ -1,8 +1,26 @@
 agent="$HOME/.ssh-agent-`hostname`"
+
 if [ -S "$agent" ]; then
     export SSH_AUTH_SOCK=$agent
-elif [ ! -S "$SSH_AUTH_SOCK" ]; then
+fi
+
+ssh-add -l &>/dev/null
+agent_status=$?
+
+if [ $agent_status -eq 2 ]; then
+    eval "$(ssh-agent -s)" > /dev/null
+    ln -snf "$SSH_AUTH_SOCK" "$agent"
     export SSH_AUTH_SOCK=$agent
-elif [ ! -L "$SSH_AUTH_SOCK" ]; then
-    ln -snf "$SSH_AUTH_SOCK" $agent && export SSH_AUTH_SOCK=$agent
+    agent_status=1
+elif [ ! -L "$agent" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+    ln -snf "$SSH_AUTH_SOCK" "$agent"
+    export SSH_AUTH_SOCK=$agent
+fi
+
+if [ $agent_status -eq 1 ]; then
+    if [ "$(uname)" = "Darwin" ]; then
+        ssh-add --apple-use-keychain
+    else
+        ssh-add
+    fi
 fi


### PR DESCRIPTION
## What

- `zsh/ssh/init.sh` に `ssh-agent` の自動起動と `ssh-add` の自動実行を追加
- macOS では `--apple-use-keychain` を使用。初回はパスフレーズを入力してキーチェーンに保存し、2回目以降はキーチェーンから自動取得
- Linux ではインタラクティブな `ssh-add` にフォールバック
- `ssh-agent` の多重起動なし（`ssh-add -l` の終了コードで状態を判定）

## Why

`ssh-agent`の起動と`ssh-add`が手動だったため自動化したい。詳細は#4参照。

Closes #4

## Test plan
