### PR TITLE
Move mise activation to zsh/mise/init.sh

### DIFF
--- a/zsh/mise/init.sh
+++ b/zsh/mise/init.sh
@@ -1,0 +1,1 @@
+eval "$(mise activate zsh)"

--- a/zshrc
+++ b/zshrc
@@ -75,4 +75,3 @@ if [ -d ~/.zsh.local ]; then
     done
 fi
 
-eval "$(mise activate zsh)"


### PR DESCRIPTION
## What

- `zsh/mise/init.sh` を新規作成し、`eval "$(mise activate zsh)"` を移動
- `zshrc` から直書きの `eval "$(mise activate zsh)"` を削除
- aqua / fzf 等の他ツールと同じ構造に統一

## Why

`go version` 実行時に aqua が `go` コマンドを横取りしてエラーになる問題を調査した際、mise の初期化が `zshrc` に直書きされており他ツール（`zsh/aqua/init.sh` 等）と構造が不統一であることが判明。本PRはその整理を行う。

> **Note:** aqua の不正な go シムの削除（`rm ~/.local/share/aquaproj-aqua/bin/go`）と `mise use --global go@` によるインストールはローカルで別途実施が必要。

## Test plan
