### PR TITLE
Add mcp-toolbox to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,5 +15,6 @@ brew "uv"
 brew "gh"
 brew "github-mcp-server"
 brew "awscli"
+brew "mc-toolbox"
 
 uv "claude-monitor"

--- a/Brewfile
+++ b/Brewfile
@@ -15,6 +15,6 @@ brew "uv"
 brew "gh"
 brew "github-mcp-server"
 brew "awscli"
-brew "mc-toolbox"
+brew "mcp-toolbox"
 
 uv "claude-monitor"


### PR DESCRIPTION
## What

- Add `mcp-toolbox` to `Brewfile` (shared between macOS and Linux)
- `mcp-toolbox` is bottled for Linux, so it works cross-platform

## Why

mcp-toolboxを使いたくなったため。

## Test plan

- [ ] Verify `mcp-toolbox` is installed via `brew bundle install --file=Brewfile`
