### PR TITLE
Add 1Password CLI and op shell plugin for AWS

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,6 +15,7 @@ brew "uv"
 brew "gh"
 brew "github-mcp-server"
 brew "awscli"
+brew "1password-cli"
 brew "mcp-toolbox"
 
 uv "claude-monitor"

--- a/zsh/op/init.sh
+++ b/zsh/op/init.sh
@@ -1,0 +1,3 @@
+if [[ -f ~/.config/op/plugins.sh ]]; then
+    source ~/.config/op/plugins.sh
+fi


### PR DESCRIPTION
## What

- `Brewfile` に `1password-cli` を追加
- `zsh/op/init.sh` を新規作成し、`~/.config/op/plugins.sh` を source する設定を追加

## Why

`op plugin init aws` で AWS 認証情報を 1Password で管理できるようにするため。`~/.config/op/plugins.sh` は 1Password CLI が自動管理するファイルのため、dotfiles 側は source するだけでよい。将来他のプラグインを追加しても `init.sh` の変更は不要。

## Test plan

- [x] `brew bundle` で `1password-cli` がインストールされること
- [x] `op plugin init aws` 実行後、新しいターミナルで `aws` コマンドが 1Password 経由で認証されること
