### PR TITLE
op/init.sh: show setup instructions when plugins not initialized

### DIFF
--- a/zsh/op/init.sh
+++ b/zsh/op/init.sh
@@ -1,3 +1,7 @@
 if [[ -f ~/.config/op/plugins.sh ]]; then
     source ~/.config/op/plugins.sh
+elif command -v op &>/dev/null; then
+    echo "1Password shell plugins not initialized. Run the following:"
+    echo "  op plugin init aws"
+    echo "  op plugin init gh"
 fi


### PR DESCRIPTION
## What

`op` がインストール済みかつ `~/.config/op/plugins.sh` が未生成の場合、初期化コマンドを案内するメッセージを表示するようにした。

## Why

新しい端末でセットアップした際、プラグイン未初期化の状態に気づきにくかった。詳細は#12参照。

Closes #12

## Test plan

- [x] `~/.config/op/plugins.sh` を削除した状態で新しいターミナルを開き、案内メッセージが表示されること
- [x] `~/.config/op/plugins.sh` が存在する場合はメッセージが表示されないこと
- [x] `op` がインストールされていない環境ではメッセージが表示されないこと
