### PR TITLE
Move 1password-cli from Brewfile to Brewfile.darwin

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,7 +15,6 @@ brew "uv"
 brew "gh"
 brew "github-mcp-server"
 brew "awscli"
-brew "1password-cli"
 brew "mcp-toolbox"
 
 uv "claude-monitor"

--- a/Brewfile.darwin
+++ b/Brewfile.darwin
@@ -1,4 +1,5 @@
 brew "pinentry-mac"
+cask "1password-cli"
 
 cask "docker-desktop"
 cask "gcloud-cli"


### PR DESCRIPTION
## What

- `1password-cli` は cask であり Linux の Homebrew では使えないため、`Brewfile` から `Brewfile.darwin` に移動した
- `brew "1password-cli"` → `cask "1password-cli"` に修正

## Why

`1password-cli`がcaskとして共通Brewfileに入っていたため、Linux環境で`make`がエラーになっていた。

## Test plan

- [x] macOS で `make` が成功すること
- [x] Linux で `make` がエラーにならないこと
