### PR TITLE
Makefile: add aqua install target to all

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,7 +15,6 @@ brew "uv"
 brew "gh"
 brew "github-mcp-server"
 brew "awscli"
-brew "1password-cli"
 brew "mcp-toolbox"
 
 uv "claude-monitor"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ UNAME := $(shell uname)
 
 .PHONY: all brew_bundle bin ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_zim zim ln_aqua clean_aqua clean_emacs clean cleanall
 
-all: .make/install_packages ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_zim
+all: .make/install_packages .make/aqua_install ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_zim
 
 ifeq ($(UNAME), Darwin)
 .make/install_packages: Brewfile Brewfile.darwin
@@ -17,6 +17,11 @@ ifeq ($(UNAME), Darwin)
 else
 	brew bundle install --file=$(PWD)/Brewfile
 endif
+	@touch $@
+
+.make/aqua_install: aqua.yaml
+	@mkdir -p .make
+	aqua install
 	@touch $@
 
 brew_bundle: Brewfile


### PR DESCRIPTION
## What

- `all` ターゲットに `.make/aqua_install` を追加
- `aqua.yaml` が変更された場合のみ `aqua install` を実行するスタンプファイル方式を採用

## Why

`make`だけではaqua管理のツールがインストールされない問題を解消する。詳細は#15参照。

Closes #15

## Test plan

- [x] `make` 実行時に `aqua install` が実行されること
- [x] `aqua.yaml` に変更がない場合は `aqua install` がスキップされること
