### PR TITLE
emacs: add Go development setup with lsp-mode and gopls

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -17,3 +17,5 @@ packages:
     version: 0.19.2
   - name: jesseduffield/lazygit
     version: v0.61.1
+  - name: golang.org/x/tools/gopls
+    version: v0.22.0

--- a/emacs.d/init.el
+++ b/emacs.d/init.el
@@ -220,6 +220,33 @@
   :config
   (add-to-list 'company-backends 'company-c-headers))
 
+;; lsp-mode
+(leaf lsp-mode
+  :doc "Language Server Protocol support"
+  :ensure t
+  :commands (lsp lsp-deferred)
+  :custom ((lsp-keymap-prefix . "C-c l")
+           (lsp-enable-snippet . nil)))
+
+(leaf lsp-ui
+  :doc "UI integrations for lsp-mode"
+  :ensure t
+  :hook (lsp-mode-hook . lsp-ui-mode)
+  :custom ((lsp-ui-doc-enable . t)
+           (lsp-ui-sideline-enable . t)))
+
+;; go
+(leaf go-mode
+  :doc "Major mode for Go source code"
+  :ensure t
+  :mode "\\.go\\'"
+  :hook (go-mode-hook . lsp-deferred)
+  :config
+  (add-hook 'go-mode-hook
+            (lambda ()
+              (add-hook 'before-save-hook #'lsp-format-buffer nil t)
+              (add-hook 'before-save-hook #'lsp-organize-imports nil t))))
+
 (provide 'init)
 
 (custom-set-variables

--- a/gitignore
+++ b/gitignore
@@ -1,0 +1,2 @@
+
+**/.claude/settings.local.json


### PR DESCRIPTION
## What

- `emacs.d/init.el`: lsp-mode、lsp-ui、go-mode を追加。保存時に自動フォーマット・import 整理
- `aqua.yaml`: gopls (v0.22.0) を追加
- `gitignore`: `.claude/settings.local.json` を除外

## Why

Emacs でGo開発をする環境を整えたかったため。あわせて、Claude Codeのプロジェクトローカル設定がgit管理に混入していたのに気づき除外した。

## Test plan
