### PR TITLE
Brewfile: add herdr

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -15,6 +15,7 @@ brew "mise"
 brew "uv"
 brew "gh"
 brew "github-mcp-server"
+brew "herdr"
 brew "awscli"
 brew "mcp-toolbox"
 


### PR DESCRIPTION
## What

- `herdr` (terminal-based agent multiplexer) を `Brewfile` に追加
- `Brewfile` は macOS/Linux 共通で読み込まれるため、両プラットフォームで対応済み
- 標準 Homebrew レジストリから `brew install herdr` でインストール可能

## Why

herdrを使い始めたため、他のツールと同様にBrewfileで宣言的に管理する。

## Test plan
