### PR TITLE
Add obsidian and make brew_bundle handle Brewfile.darwin transparently

### DIFF
--- a/Brewfile.darwin
+++ b/Brewfile.darwin
@@ -3,6 +3,7 @@ brew "terminal-notifier"
 
 cask "docker-desktop"
 cask "gcloud-cli"
+cask "obsidian"
 cask "vagrant"
 cask "vagrant-vmware-utility"
 cask "virtualbox"

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,15 @@ endif
 	aqua install
 	@touch $@
 
+ifeq ($(UNAME), Darwin)
+brew_bundle: Brewfile Brewfile.darwin
+else
 brew_bundle: Brewfile
+endif
 	brew bundle install --file=$(PWD)/Brewfile
+ifeq ($(UNAME), Darwin)
+	brew bundle install --file=$(PWD)/Brewfile.darwin
+endif
 
 bin: ln_bin
 


### PR DESCRIPTION
## What

- Add obsidian to Brewfile.darwin
- Make `make brew_bundle` install Brewfile.darwin automatically on Darwin, so mac-only packages no longer need a separate manual step

## Why

Obsidianを使い始めたため導入。あわせて、Brewfile.darwinを別途手動実行する必要があった手間を解消する。

## Test plan

- [x] Ran `make brew_bundle` on macOS and confirmed both Brewfile and Brewfile.darwin (including obsidian) were installed
