### PR TITLE
Brewfile.darwin: add clipory

### DIFF
--- a/Brewfile.darwin
+++ b/Brewfile.darwin
@@ -1,6 +1,7 @@
 brew "pinentry-mac"
 brew "terminal-notifier"
 
+cask "clipory/tap/clipory"
 cask "docker-desktop"
 cask "gcloud-cli"
 cask "obsidian"


### PR DESCRIPTION
## What

Add clipory cask (clipory/tap/clipory) to Brewfile.darwin

## Why

cliporyを使いたくなったため、他のツールと同様に宣言ファイルで管理する。

## Test plan

- [x] Ran `make` on macOS, installed successfully (required `brew trust --cask clipory/tap/clipory` for the third-party tap)
