### PR TITLE
herdr-config: set sidebar min/max width to 32/36

### DIFF
--- a/herdr-config.toml
+++ b/herdr-config.toml
@@ -14,6 +14,8 @@ agent_panel_sort = "spaces"
 confirm_close = true
 prompt_new_tab_name = false
 show_agent_labels_on_pane_borders = true
+sidebar_min_width = 32
+sidebar_max_width = 36
 
 [ui.toast]
 delivery = "herdr"


### PR DESCRIPTION
## What

Set `sidebar_min_width = 32` and `sidebar_max_width = 36` in herdr-config.toml (replacing implicit default sidebar width behavior).

## Why

デフォルトのサイドバー幅の挙動より、明示的に幅を固定した方が使いやすかったため。

## Test plan

- [x] Verified `sidebar_min_width`/`sidebar_max_width` are valid config keys (confirmed via herdr binary strings)
