### PR TITLE
herdr-config: fix prefix+u keybinding type to shell

### DIFF
--- a/herdr-config.toml
+++ b/herdr-config.toml
@@ -26,5 +26,5 @@ enabled = false
 
 [[keys.command]]
 key = "prefix+u"
-type = "pane"
+type = "shell"
 command = "/Users/travail/bin/herdr-unread"


### PR DESCRIPTION
## What

`prefix+u`のtypeを`"pane"`から`"shell"`に変更（バックグラウンドで動く形に）。

## Why

`prefix+u` (`herdr-unread`) は`type = "pane"`に設定されており、呼び出すたびに一時的なフルスクリーンpaneが開いていた。`herdr-unread`はフォーカスを移すだけで何も描画しないため、`type = "shell"`（デタッチして裏で実行）にすべきだった。

## Test plan

- [x] Applied via `herdr server reload-config` and confirmed `prefix+u` no longer flashes a fullscreen pane
