### PR TITLE
zsh/op: gh/awsをService Accountベースの非対話認証に切り替え

### DIFF
--- a/zsh/op/aws.env
+++ b/zsh/op/aws.env
@@ -1,0 +1,2 @@
+AWS_ACCESS_KEY_ID=op://wgd2n73rvd4jnz2tgjeielvllm/5m43gu4b7a2jx7s4nwuvb4s6fa/access key id
+AWS_SECRET_ACCESS_KEY=op://wgd2n73rvd4jnz2tgjeielvllm/5m43gu4b7a2jx7s4nwuvb4s6fa/secret access key

--- a/zsh/op/gh.env
+++ b/zsh/op/gh.env
@@ -1,0 +1,1 @@
+GH_TOKEN=op://wgd2n73rvd4jnz2tgjeielvllm/xdllwd6vv7tw53gxcfspvhymhq/token

--- a/zsh/op/init.sh
+++ b/zsh/op/init.sh
@@ -1,7 +1,8 @@
-if [[ -f ~/.config/op/plugins.sh ]]; then
-    source ~/.config/op/plugins.sh
+if [[ -f ~/.config/op/service-account-token ]]; then
+    export OP_SERVICE_ACCOUNT_TOKEN="$(<~/.config/op/service-account-token)"
+    gh() { op run --env-file="$HOME/.zsh/op/gh.env" -- gh "$@" }
+    aws() { op run --env-file="$HOME/.zsh/op/aws.env" -- aws "$@" }
 elif command -v op &>/dev/null; then
-    echo "1Password shell plugins not initialized. Run the following:"
-    echo "  op plugin init aws"
-    echo "  op plugin init gh"
+    echo "1Password service account token not found. Save it to:"
+    echo "  ~/.config/op/service-account-token (chmod 600)"
 fi


### PR DESCRIPTION
## What

- shell plugin方式 (`op plugin run`) は呼び出しごとに生体認証を要求する設計で、Claude Code の Bash tool から実行すると毎回新しいシェルセッション扱いになり高頻度でプロンプトが出ていた
- 1Password Service Accountsは `op read`/`op inject`/`op run`/SDK には対応するが shell plugins には非対応のため、`op plugin run` ベースの仕組みを `op run --env-file` ベースに置き換えた
- gh/aws用のcredentialを専用vault「API Keys & Tokens」に集約し、Service Account「development」にそのvaultのみへの読み取り権限を付与
- Service Account tokenはOS非依存のローカルファイル(`~/.config/op/service-account-token`, chmod 600, git管理外)に保存し、シェル起動時に読み込む

## Why

詳細な背景・検討はissue #29参照。要点は、shell plugin方式の生体認証プロンプトがAIエージェントからの利用と相性が悪かったこと。

Closes #29

## Test plan

- [x] 新規シェル・クリーン環境で `gh issue list` / `aws sts get-caller-identity` が生体認証プロンプトなしで成功することを確認
- [x] `git diff` で `zsh/op/gh.env` / `zsh/op/aws.env` に生の秘密情報(token/key)が含まれておらず、`op://`参照のみであることを確認
