### PR TITLE
zsh/op/init.sh: 古いgh/awsのaliasが残っている場合のparse errorを修正

### DIFF
--- a/zsh/op/init.sh
+++ b/zsh/op/init.sh
@@ -1,3 +1,9 @@
+# A stale `alias gh=...`/`alias aws=...` from an older shell plugin setup makes
+# zsh error out when redefining them as functions below. zsh resolves aliases
+# while parsing, so this must run as its own statement before the `if` block
+# below is parsed, not just before it runs.
+unalias gh aws 2>/dev/null
+
 if [[ -f ~/.config/op/service-account-token ]]; then
     export OP_SERVICE_ACCOUNT_TOKEN="$(<~/.config/op/service-account-token)"
     gh() { op run --env-file="$HOME/.zsh/op/gh.env" -- gh "$@" }


### PR DESCRIPTION
## What

`unalias gh aws 2>/dev/null` を`if`文の外の独立した文としてファイル先頭に移動することで解消した。

## Why

以前のshell plugin方式(`op plugin run`)で定義された `alias gh=...` / `alias aws=...` が既存シェルに残っている状態で `zsh/op/init.sh` をsource（またはshell起動時に読み込み）すると、`defining function based on alias` parse errorになりsource全体が失敗していた。zshはalias解決をparse時に行うため、`if`文の中で`unalias`してから同じ`if`文の中で`gh()`関数を定義しても間に合わない（`if...fi`全体が1つの構文単位としてparseされるため）。

## Test plan

- [x] `alias gh=...`/`alias aws=...` が事前に定義された状態で`source zsh/op/init.sh`しても parse errorが出ず、`gh`/`aws`が正しく関数として再定義されることを確認
- [x] 通常時（alias未定義）でも同様に正しく関数定義されることを確認
- [x] 修正後のinit.sh経由で実際に`gh issue list`が成功することを確認
