### PR TITLE
herdr-config: last_pane と workspace navigation のキーバインドを追加

### DIFF
--- a/herdr-config.toml
+++ b/herdr-config.toml
@@ -6,9 +6,12 @@ auto_switch = false
 prefix = "ctrl+t"
 next_tab = "prefix+ctrl+n"
 previous_tab = "prefix+ctrl+p"
+next_workspace = "prefix+ctrl+shift+n"
+previous_workspace = "prefix+ctrl+shift+p"
 previous_agent = "prefix+,"
 next_agent = "prefix+."
 focus_agent = "prefix+ctrl+1..9"
+last_pane = "prefix+p"
 
 [ui]
 agent_panel_sort = "spaces"


### PR DESCRIPTION
## What

- `last_pane` を `prefix+p` に割り当て。直前フォーカスしていたpaneへの双方向トグル（`prefix+u`で未読paneに移動した後、すぐ元のpaneに戻れる）
- `next_workspace`/`previous_workspace` を `prefix+ctrl+shift+n`/`prefix+ctrl+shift+p` に割り当て。既存の tab 用 `prefix+ctrl+n`/`prefix+ctrl+p` と揃えた階層

## Why

複数workspace・複数paneを行き来する頻度が上がったため、キーバインドで素早く移動・往復できるようにしたい。

## Test plan

- [x] `herdr server reload-config` でdiagnosticsなく適用されることを確認
