### PR TITLE
bin/herdr-init: workspace初回初期化時のtrustダイアログ競合を修正

### DIFF
--- a/bin/herdr-init
+++ b/bin/herdr-init
@@ -42,7 +42,7 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
-DIR="$1"
+DIR=$(cd "$1" && pwd)
 PREFIX="${2:-$(basename "$DIR")}"
 
 WS_JSON=$(herdr workspace create --cwd "$DIR" --label "$PREFIX")
@@ -63,16 +63,31 @@ herdr pane rename "$BOTTOM_RIGHT" "$PREFIX-p3"
 for PANE in "$BOTTOM_LEFT" "$TOP_RIGHT" "$BOTTOM_RIGHT"; do
   herdr pane run "$PANE" "claude"
   # herdr needs a moment to detect the freshly spawned agent, and the first
-  # run in an untrusted directory shows a one-time trust prompt (herdr
-  # reports agent_status idle even while that prompt is up). Keep dismissing
-  # the prompt and polling until the agent is actually detected.
+  # run in a not-yet-trusted directory shows a one-time trust prompt (herdr
+  # reports agent_status idle even while that prompt is up). `herdr agent get`
+  # can succeed *before* the prompt has even been rendered, so a single
+  # successful check isn't proof the prompt won't show up. Only pay for the
+  # extra confirmation delay when the directory isn't already trusted (per
+  # ~/.claude.json) -- once any pane accepts the prompt, the directory is
+  # trusted for the rest of this loop too, so this is re-checked per pane.
+  TRUSTED=$(jq -r --arg d "$DIR" '.projects[$d].hasTrustDialogAccepted // false' "$HOME/.claude.json" 2>/dev/null || echo false)
+  if [ "$TRUSTED" = "true" ]; then
+    REQUIRED_CLEAN=1
+  else
+    REQUIRED_CLEAN=4
+  fi
+  CLEAN_CHECKS=0
   for _ in $(seq 1 30); do
     if herdr pane read "$PANE" --source recent --lines 20 2>/dev/null | grep -q "trust this folder"; then
       herdr pane send-keys "$PANE" Enter
+      CLEAN_CHECKS=0
       sleep 0.5
       continue
     fi
-    herdr agent get "$PANE" >/dev/null 2>&1 && break
+    CLEAN_CHECKS=$((CLEAN_CHECKS + 1))
+    if [ "$CLEAN_CHECKS" -ge "$REQUIRED_CLEAN" ] && herdr agent get "$PANE" >/dev/null 2>&1; then
+      break
+    fi
     sleep 0.5
   done
   herdr agent wait "$PANE" --until idle --timeout 15000


### PR DESCRIPTION
## What

`agent get`の成功を信頼する前に「ダイアログのテキストが無い」ことを複数回連続で確認するようにした。ただしこの追加確認は対象ディレクトリが`~/.claude.json`上でまだ信用されていない場合のみ行い、既に信用済みのディレクトリでは元通り即座にbreakする高速パスを維持。

## Why

まだherdrが信用していないディレクトリに対して`herdr-init`を実行すると、Claude Codeのtrustダイアログがpane内で放置されたまま止まってしまうことがあった。`herdr agent get`がダイアログの描画より先に成功してしまうことがあり、待機ループが早期にbreakしてEnterが送られないままになっていたのが原因。

## Test plan

- [x] Claude Codeが一度も見たことのないディレクトリに対して`herdr-init`を実行し、3つのclaude paneすべてが通常のwelcome画面に到達すること（trustダイアログで止まらないこと）、`~/.claude.json`に`hasTrustDialogAccepted`が記録されることを確認
- [x] 同じ（既に信用済みになった）ディレクトリで再実行し、修正前と同等の速度（約1.85秒）で完了することを確認
- [x] テストで作成したworkspace/ディレクトリ/`~/.claude.json`のエントリを後片付け
