### PR TITLE
herdr-init: agent paneをオンデマンドで起動できるようにする

### DIFF
--- a/bin/herdr-common.sh
+++ b/bin/herdr-common.sh
@@ -1,0 +1,57 @@
+# Shared helpers for herdr-init / herdr-spawn-agent. Source only, not
+# executable. Callers must have `set -euo pipefail` in effect.
+
+# spawn_and_prime_agent PANE_ID [PRIME=1]
+#   Spawns `claude` in PANE_ID, clears the one-time trust-dialog prompt if it
+#   appears, and waits for the agent to go idle. Unless PRIME=0, also sends
+#   `/herdr` to preload the herdr CLI skill and waits idle again.
+spawn_and_prime_agent() {
+  local pane="$1" prime="${2:-1}"
+
+  herdr pane run "$pane" "claude" >&2
+
+  # herdr needs a moment to detect the freshly spawned agent, and the first
+  # run in a not-yet-trusted directory shows a one-time trust prompt (herdr
+  # reports agent_status idle even while that prompt is up). `herdr agent get`
+  # can succeed *before* the prompt has even been rendered, so a single
+  # successful check isn't proof the prompt won't show up. Only pay for the
+  # extra confirmation delay when the directory isn't already trusted (per
+  # ~/.claude.json).
+  #
+  # cwd is looked up per-pane (not passed in by the caller) so this works
+  # whether it's called against herdr-init's root pane or a pane
+  # herdr-spawn-agent just split off elsewhere.
+  local dir trusted required_clean clean_checks
+  dir=$(herdr pane get "$pane" | jq -r '.result.pane.cwd')
+  trusted=$(jq -r --arg d "$dir" '.projects[$d].hasTrustDialogAccepted // false' \
+            "$HOME/.claude.json" 2>/dev/null || echo false)
+  if [ "$trusted" = "true" ]; then
+    required_clean=1
+  else
+    required_clean=4
+  fi
+
+  clean_checks=0
+  for _ in $(seq 1 30); do
+    if herdr pane read "$pane" --source recent --lines 20 2>/dev/null | grep -q "trust this folder"; then
+      herdr pane send-keys "$pane" Enter
+      clean_checks=0
+      sleep 0.5
+      continue
+    fi
+    clean_checks=$((clean_checks + 1))
+    if [ "$clean_checks" -ge "$required_clean" ] && herdr agent get "$pane" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.5
+  done
+  herdr agent wait "$pane" --until idle --timeout 15000 >&2
+
+  if [ "$prime" -eq 1 ]; then
+    # Prime the agent with the herdr skill up front, so it can act as hub
+    # (dispatch to/pull from sibling panes) without the user having to
+    # explain herdr in the task prompt.
+    herdr pane run "$pane" "/herdr" >&2
+    herdr agent wait "$pane" --until idle --timeout 15000 >&2
+  fi
+}

--- a/bin/herdr-id
+++ b/bin/herdr-id
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+# Resolve a herdr workspace/pane/agent label to its current id, for use in
+# command substitution, e.g.:
+#   herdr workspace close "$(herdr-id -w dotfiles)"
+#   herdr pane rename "$(herdr-id -p dotfiles-p0)" new-name
+#   herdr pane run "$(herdr-id -a dotfiles-a1)" "echo hi"
+#
+# Note: herdr agent commands already accept labels directly as targets,
+# so -a is mainly useful when you need the underlying pane_id (e.g. to
+# hand it to a pane subcommand).
+#
+# Usage: herdr-id -w|-p|-a <label>
+
+usage() {
+  echo "usage: herdr-id -w|-p|-a <label>" >&2
+  exit 1
+}
+
+[ $# -eq 2 ] || usage
+OPT="$1"
+LABEL="$2"
+
+case "$OPT" in
+  -w)
+    TYPE="workspace"
+    MATCHES=$(herdr workspace list | jq -r --arg l "$LABEL" '.result.workspaces[] | select(.label == $l) | .workspace_id')
+    ;;
+  -p)
+    TYPE="pane"
+    MATCHES=$(herdr pane list | jq -r --arg l "$LABEL" '.result.panes[] | select(.label == $l) | .pane_id')
+    ;;
+  -a)
+    TYPE="agent"
+    MATCHES=$(herdr agent list | jq -r --arg l "$LABEL" '.result.agents[] | select(.name == $l) | .pane_id')
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+if [ -z "$MATCHES" ]; then
+  echo "herdr-id: no $TYPE with label '$LABEL'" >&2
+  exit 1
+fi
+
+if [ "$(echo "$MATCHES" | wc -l)" -gt 1 ]; then
+  echo "herdr-id: multiple ${TYPE}s with label '$LABEL':" >&2
+  echo "$MATCHES" >&2
+  exit 1
+fi
+
+echo "$MATCHES"

--- a/bin/herdr-init
+++ b/bin/herdr-init
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -euo pipefail
-# Set up a new herdr workspace with a 2x2 pane layout, panes renamed p0-p3:
-#   p0 (top-left)     plain shell
-#   p1 (bottom-left)  claude
-#   p2 (top-right)    claude
-#   p3 (bottom-right) claude
+# Set up a new herdr workspace, editor-style: p1 (hub agent, ~70%) on top,
+# p0 (plain shell, ~30%) below it, like a terminal panel under an editor.
+#
+# Additional agent panes (p2, p3, p4, ...) are NOT pre-created here -- spawn
+# them on demand with `herdr-spawn-agent` once you actually need them, to
+# avoid paying process + /herdr skill-load cost for panes that mostly sit
+# idle.
 #
 # Agents are intentionally left unnamed: agent.name does not survive a herdr
 # server restart (e.g. after an update), while pane labels do, so renaming
@@ -45,52 +47,22 @@ fi
 DIR=$(cd "$1" && pwd)
 PREFIX="${2:-$(basename "$DIR")}"
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/herdr-common.sh"
+
 WS_JSON=$(herdr workspace create --cwd "$DIR" --label "$PREFIX")
 WORKSPACE_ID=$(echo "$WS_JSON" | jq -r '.result.workspace.workspace_id')
 ROOT_PANE=$(echo "$WS_JSON" | jq -r '.result.root_pane.pane_id')
 
-TOP_RIGHT=$(herdr pane split "$ROOT_PANE" --direction right --no-focus | jq -r '.result.pane.pane_id')
-BOTTOM_LEFT=$(herdr pane split "$ROOT_PANE" --direction down --no-focus | jq -r '.result.pane.pane_id')
-BOTTOM_RIGHT=$(herdr pane split "$TOP_RIGHT" --direction down --no-focus | jq -r '.result.pane.pane_id')
+# ROOT_PANE stays p1 (hub agent). Split it downward to carve out p0, a plain
+# shell strip below it. --ratio sizes the pane being split (the staying
+# side), so --ratio 0.7 keeps p1 at ~70% and leaves ~30% for the new p0.
+BOTTOM=$(herdr pane split "$ROOT_PANE" --direction down --ratio 0.7 --no-focus \
+         | jq -r '.result.pane.pane_id')
 
-TOP_LEFT="$ROOT_PANE"
+herdr pane rename "$ROOT_PANE" "$PREFIX-p1"
+herdr pane rename "$BOTTOM" "$PREFIX-p0"
 
-herdr pane rename "$TOP_LEFT" "$PREFIX-p0"
-herdr pane rename "$BOTTOM_LEFT" "$PREFIX-p1"
-herdr pane rename "$TOP_RIGHT" "$PREFIX-p2"
-herdr pane rename "$BOTTOM_RIGHT" "$PREFIX-p3"
-
-for PANE in "$BOTTOM_LEFT" "$TOP_RIGHT" "$BOTTOM_RIGHT"; do
-  herdr pane run "$PANE" "claude"
-  # herdr needs a moment to detect the freshly spawned agent, and the first
-  # run in a not-yet-trusted directory shows a one-time trust prompt (herdr
-  # reports agent_status idle even while that prompt is up). `herdr agent get`
-  # can succeed *before* the prompt has even been rendered, so a single
-  # successful check isn't proof the prompt won't show up. Only pay for the
-  # extra confirmation delay when the directory isn't already trusted (per
-  # ~/.claude.json) -- once any pane accepts the prompt, the directory is
-  # trusted for the rest of this loop too, so this is re-checked per pane.
-  TRUSTED=$(jq -r --arg d "$DIR" '.projects[$d].hasTrustDialogAccepted // false' "$HOME/.claude.json" 2>/dev/null || echo false)
-  if [ "$TRUSTED" = "true" ]; then
-    REQUIRED_CLEAN=1
-  else
-    REQUIRED_CLEAN=4
-  fi
-  CLEAN_CHECKS=0
-  for _ in $(seq 1 30); do
-    if herdr pane read "$PANE" --source recent --lines 20 2>/dev/null | grep -q "trust this folder"; then
-      herdr pane send-keys "$PANE" Enter
-      CLEAN_CHECKS=0
-      sleep 0.5
-      continue
-    fi
-    CLEAN_CHECKS=$((CLEAN_CHECKS + 1))
-    if [ "$CLEAN_CHECKS" -ge "$REQUIRED_CLEAN" ] && herdr agent get "$PANE" >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.5
-  done
-  herdr agent wait "$PANE" --until idle --timeout 15000
-done
+spawn_and_prime_agent "$ROOT_PANE"
 
 herdr workspace focus "$WORKSPACE_ID"

--- a/bin/herdr-spawn-agent
+++ b/bin/herdr-spawn-agent
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -euo pipefail
+# On-demand: split an existing pane and spawn+prime a claude agent in the new
+# pane. Meant to be called either by a human or by a hub agent (via a Bash
+# tool call) once it actually needs to delegate to a role that doesn't have a
+# pane yet -- see bin/herdr-init, which only pre-creates the hub pane (p1).
+#
+# Prints ONLY the new pane's id to stdout, so it's safe to capture via
+# command substitution. All progress/diagnostics go to stderr.
+
+usage() {
+  cat <<'EOF'
+Usage: herdr-spawn-agent [-h] [-r RATIO] [-l LABEL] [-n] [-f] <target> <right|down>
+
+Arguments:
+  target      Pane id or label to split (e.g. dotfiles-p1). (required)
+  right|down  Which side of target the new pane appears on. (required)
+
+Options:
+  -r RATIO  Size ratio, passed through to `herdr pane split --ratio`
+            (sizes the pane being split, i.e. target -- the new pane gets
+            the remainder).
+  -l LABEL  Explicit label for the new pane. (default: auto-derived as
+            "<workspace-label>-pN", N = 1 + highest existing pM in the
+            workspace)
+  -n        Skip the /herdr preload step (spawn + clear trust dialog only).
+  -f        Focus the new pane after creating it. (default: unfocused)
+  -h        Show this help and exit.
+EOF
+}
+
+RATIO=""
+LABEL=""
+PRIME=1
+FOCUS_FLAG="--no-focus"
+
+while getopts "r:l:nfh" OPT; do
+  case "$OPT" in
+    r)
+      RATIO="$OPTARG"
+      ;;
+    l)
+      LABEL="$OPTARG"
+      ;;
+    n)
+      PRIME=0
+      ;;
+    f)
+      FOCUS_FLAG="--focus"
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ $# -ne 2 ]; then
+  usage >&2
+  exit 1
+fi
+
+TARGET_REF="$1"
+DIRECTION="$2"
+
+case "$DIRECTION" in
+  right | down) ;;
+  *)
+    echo "herdr-spawn-agent: direction must be 'right' or 'down'" >&2
+    exit 1
+    ;;
+esac
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/herdr-common.sh"
+
+# pane_ids contain a colon (e.g. w1:p1), labels don't -- same convention
+# herdr-id itself uses.
+case "$TARGET_REF" in
+  *:*)
+    TARGET_PANE="$TARGET_REF"
+    ;;
+  *)
+    TARGET_PANE=$("$SCRIPT_DIR/herdr-id" -p "$TARGET_REF")
+    ;;
+esac
+
+WORKSPACE_ID=$(herdr pane get "$TARGET_PANE" | jq -r '.result.pane.workspace_id')
+
+echo "herdr-spawn-agent: splitting $TARGET_PANE ($DIRECTION)..." >&2
+SPLIT_ARGS=(herdr pane split "$TARGET_PANE" --direction "$DIRECTION" "$FOCUS_FLAG")
+if [ -n "$RATIO" ]; then
+  SPLIT_ARGS+=(--ratio "$RATIO")
+fi
+NEW_PANE=$("${SPLIT_ARGS[@]}" | jq -r '.result.pane.pane_id')
+
+if [ -z "$LABEL" ]; then
+  # Derive the prefix from the workspace's own label (not the target pane's
+  # label) so this stays correct even if panes were manually renamed.
+  PREFIX=$(herdr workspace get "$WORKSPACE_ID" | jq -r '.result.workspace.label')
+  MAX_N=$(herdr pane list --workspace "$WORKSPACE_ID" | jq -r --arg p "$PREFIX" '
+    .result.panes[].label // empty
+    | select(test("^" + $p + "-p[0-9]+$"))
+    | sub("^" + $p + "-p"; "") | tonumber' | sort -n | tail -1)
+  LABEL="${PREFIX}-p$(( ${MAX_N:-0} + 1 ))"
+fi
+herdr pane rename "$NEW_PANE" "$LABEL" >&2
+
+echo "herdr-spawn-agent: spawning claude in $NEW_PANE ($LABEL)..." >&2
+spawn_and_prime_agent "$NEW_PANE" "$PRIME"
+
+echo "$NEW_PANE"


### PR DESCRIPTION
## What

- `herdr-init`が固定2x2グリッド（p1〜p3すべてに`claude`を事前起動）を毎回作るのをやめ、p1（hubエージェント、`/herdr`preload済み、~70%）+p0（普通のシェル、p1の下、~30%）だけを作る最小構成に変更
- 新規`bin/herdr-spawn-agent`で、必要になった時にオンデマンドでagent paneを追加できるようにした（既存paneをsplitしてagentを起動し、新paneのpane_idのみを標準出力する）
- trust-dialog待機＋`/herdr`preloadの共有ロジックを`bin/herdr-common.sh`に切り出し、`herdr-init`と`herdr-spawn-agent`で重複させない
- 未追跡のままだった`bin/herdr-id`もあわせてコミット
- `~/.claude/CLAUDE.md`のherdrセクションを、hubエージェントがこの新しい構成（labelではなく実際のpane rectから次にsplitすべきpaneを判断する等）を踏まえて動けるように更新（このリポジトリ管理外のため別途反映済み）

## Why

実際にはp2/p3がほとんど使われずアイドルのままだったため、プロセスと`/herdr`スキルロードのコストが無駄になっていた（詳細は#36参照）。

Refs #36

## Test plan

- [x] scratch workspaceで`herdr pane split --ratio`の意味（split元/残る側のサイズを指定する）を実機確認
- [x] scratch workspaceで`herdr-init` → `herdr-spawn-agent p1 down` → `herdr-spawn-agent p1 right` → `herdr-spawn-agent p2 right`の拡張手順を実行し、p1(左上)/p3(右上)/p2(左下)/p4(右下)の2x2グリッドがp0(下部横長帯)の上に正しく乗ることを確認
- [x] `herdr-spawn-agent`の標準出力が新paneのpane_id一行のみになることを確認（rename/waitの出力をstderrへリダイレクト）
