### PR TITLE
herdr-init/herdr-spawn-agentのpane labelとpane idの数字を統一する

### DIFF
--- a/bin/herdr-common.sh
+++ b/bin/herdr-common.sh
@@ -10,48 +10,76 @@ spawn_and_prime_agent() {
 
   herdr pane run "$pane" "claude" >&2
 
-  # herdr needs a moment to detect the freshly spawned agent, and the first
-  # run in a not-yet-trusted directory shows a one-time trust prompt (herdr
-  # reports agent_status idle even while that prompt is up). `herdr agent get`
-  # can succeed *before* the prompt has even been rendered, so a single
-  # successful check isn't proof the prompt won't show up. Only pay for the
-  # extra confirmation delay when the directory isn't already trusted (per
-  # ~/.claude.json).
+  # herdr needs a moment to detect the freshly spawned agent -- `herdr agent
+  # wait` errors immediately (no retry) if the target isn't registered yet,
+  # so some polling is unavoidable here regardless of trust state.
+  #
+  # The first run in a not-yet-trusted directory additionally shows a
+  # one-time trust prompt (herdr reports agent_status idle even while that
+  # prompt is up), and `herdr agent get` can succeed *before* the prompt has
+  # even been rendered, so a single successful check isn't proof the prompt
+  # won't show up -- that path polls for the prompt text and requires a few
+  # consecutive clean reads. Once a directory is trusted (per
+  # ~/.claude.json), the prompt can never show again for it, so that check
+  # is skipped entirely -- just poll for the agent to be detected.
   #
   # cwd is looked up per-pane (not passed in by the caller) so this works
   # whether it's called against herdr-init's root pane or a pane
   # herdr-spawn-agent just split off elsewhere.
-  local dir trusted required_clean clean_checks
+  local dir trusted
   dir=$(herdr pane get "$pane" | jq -r '.result.pane.cwd')
   trusted=$(jq -r --arg d "$dir" '.projects[$d].hasTrustDialogAccepted // false' \
             "$HOME/.claude.json" 2>/dev/null || echo false)
-  if [ "$trusted" = "true" ]; then
-    required_clean=1
-  else
-    required_clean=4
-  fi
 
-  clean_checks=0
-  for _ in $(seq 1 30); do
-    if herdr pane read "$pane" --source recent --lines 20 2>/dev/null | grep -q "trust this folder"; then
-      herdr pane send-keys "$pane" Enter
-      clean_checks=0
-      sleep 0.5
-      continue
-    fi
-    clean_checks=$((clean_checks + 1))
-    if [ "$clean_checks" -ge "$required_clean" ] && herdr agent get "$pane" >/dev/null 2>&1; then
-      break
-    fi
-    sleep 0.5
-  done
+  if [ "$trusted" = "true" ]; then
+    for _ in $(seq 1 150); do
+      herdr agent get "$pane" >/dev/null 2>&1 && break
+      sleep 0.1
+    done
+  else
+    local clean_checks=0
+    for _ in $(seq 1 150); do
+      if herdr pane read "$pane" --source recent --lines 20 2>/dev/null | grep -q "trust this folder"; then
+        herdr pane send-keys "$pane" Enter
+        clean_checks=0
+        sleep 0.1
+        continue
+      fi
+      clean_checks=$((clean_checks + 1))
+      if [ "$clean_checks" -ge 4 ] && herdr agent get "$pane" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.1
+    done
+  fi
   herdr agent wait "$pane" --until idle --timeout 15000 >&2
 
   if [ "$prime" -eq 1 ]; then
     # Prime the agent with the herdr skill up front, so it can act as hub
     # (dispatch to/pull from sibling panes) without the user having to
     # explain herdr in the task prompt.
-    herdr pane run "$pane" "/herdr" >&2
+    #
+    # A freshly spawned agent can report idle (via the wait right above)
+    # slightly before its terminal UI is actually ready to receive input --
+    # sending "/herdr" right at that instant can silently go nowhere
+    # (verified empirically: the pane's prompt stays completely empty,
+    # never even shows "/herdr" having been typed). Give it a moment to
+    # settle, then confirm the agent actually transitioned to working
+    # (proof the input was received and processing started, not just that
+    # it was still sitting idle) -- retrying the send a couple of times if
+    # it doesn't.
+    sleep 1
+    local primed=0
+    for _ in $(seq 1 3); do
+      herdr pane run "$pane" "/herdr" >&2
+      if herdr agent wait "$pane" --until working --timeout 3000 >&2; then
+        primed=1
+        break
+      fi
+    done
+    if [ "$primed" -eq 0 ]; then
+      echo "spawn_and_prime_agent: warning: /herdr priming may not have reached $pane" >&2
+    fi
     herdr agent wait "$pane" --until idle --timeout 15000 >&2
   fi
 }

--- a/bin/herdr-init
+++ b/bin/herdr-init
@@ -1,12 +1,26 @@
 #!/bin/bash
 set -euo pipefail
-# Set up a new herdr workspace, editor-style: p1 (hub agent, ~70%) on top,
-# p0 (plain shell, ~30%) below it, like a terminal panel under an editor.
+# Set up a new herdr workspace, editor-style: the hub agent pane (~70%) on
+# top, a plain shell terminal strip (~30%) at the bottom, like a terminal
+# panel under an editor.
 #
-# Additional agent panes (p2, p3, p4, ...) are NOT pre-created here -- spawn
-# them on demand with `herdr-spawn-agent` once you actually need them, to
-# avoid paying process + /herdr skill-load cost for panes that mostly sit
-# idle.
+# The workspace root pane (always the first pane, created by `herdr
+# workspace create`) stays the plain terminal; the pane split off from it
+# becomes the hub agent. herdr's `pane split` only supports `right`/`down`,
+# and always keeps the split target in the "before" position (top for
+# `down`) -- so a plain split alone can't put the root pane at the bottom.
+# Instead we split down (root pane large, new pane small -- backwards from
+# the final layout) and then `pane swap` the two, which exchanges each
+# pane's full rect (position + size): the root pane/terminal ends up small
+# at the bottom, and the new pane/hub ends up large at the top.
+#
+# Pane labels always mirror herdr's own pane_id suffix verbatim (see the
+# rename calls below) rather than hardcoding numbers, so label and pane_id
+# always agree by construction.
+#
+# Additional agent panes are NOT pre-created here -- spawn them on demand
+# with `herdr-spawn-agent` once you actually need them, to avoid paying
+# process + /herdr skill-load cost for panes that mostly sit idle.
 #
 # Agents are intentionally left unnamed: agent.name does not survive a herdr
 # server restart (e.g. after an update), while pane labels do, so renaming
@@ -54,15 +68,20 @@ WS_JSON=$(herdr workspace create --cwd "$DIR" --label "$PREFIX")
 WORKSPACE_ID=$(echo "$WS_JSON" | jq -r '.result.workspace.workspace_id')
 ROOT_PANE=$(echo "$WS_JSON" | jq -r '.result.root_pane.pane_id')
 
-# ROOT_PANE stays p1 (hub agent). Split it downward to carve out p0, a plain
-# shell strip below it. --ratio sizes the pane being split (the staying
-# side), so --ratio 0.7 keeps p1 at ~70% and leaves ~30% for the new p0.
-BOTTOM=$(herdr pane split "$ROOT_PANE" --direction down --ratio 0.7 --no-focus \
-         | jq -r '.result.pane.pane_id')
+# ROOT_PANE is always the first pane created in the workspace, so it becomes
+# the plain shell. Split it down at ratio 0.7 (ROOT_PANE large/top, new pane
+# small/bottom -- backwards from the final layout), then swap the two so
+# ROOT_PANE (terminal) ends up small at the bottom and the new pane (hub)
+# ends up large at the top.
+HUB_PANE=$(herdr pane split "$ROOT_PANE" --direction down --ratio 0.7 --no-focus \
+           | jq -r '.result.pane.pane_id')
+herdr pane swap --source-pane "$ROOT_PANE" --target-pane "$HUB_PANE" >&2
 
-herdr pane rename "$ROOT_PANE" "$PREFIX-p1"
-herdr pane rename "$BOTTOM" "$PREFIX-p0"
+# Mirror herdr's own pane_id suffix (everything after the colon in wN:pM)
+# verbatim -- never parsed as a number -- so label and id always agree.
+herdr pane rename "$ROOT_PANE" "$PREFIX-${ROOT_PANE#*:}"
+herdr pane rename "$HUB_PANE" "$PREFIX-${HUB_PANE#*:}"
 
-spawn_and_prime_agent "$ROOT_PANE"
+spawn_and_prime_agent "$HUB_PANE"
 
 herdr workspace focus "$WORKSPACE_ID"

--- a/bin/herdr-spawn-agent
+++ b/bin/herdr-spawn-agent
@@ -3,7 +3,8 @@ set -euo pipefail
 # On-demand: split an existing pane and spawn+prime a claude agent in the new
 # pane. Meant to be called either by a human or by a hub agent (via a Bash
 # tool call) once it actually needs to delegate to a role that doesn't have a
-# pane yet -- see bin/herdr-init, which only pre-creates the hub pane (p1).
+# pane yet -- see bin/herdr-init, which only pre-creates the terminal (root)
+# and hub agent panes.
 #
 # Prints ONLY the new pane's id to stdout, so it's safe to capture via
 # command substitution. All progress/diagnostics go to stderr.
@@ -20,9 +21,10 @@ Options:
   -r RATIO  Size ratio, passed through to `herdr pane split --ratio`
             (sizes the pane being split, i.e. target -- the new pane gets
             the remainder).
-  -l LABEL  Explicit label for the new pane. (default: auto-derived as
-            "<workspace-label>-pN", N = 1 + highest existing pM in the
-            workspace)
+  -l LABEL  Explicit label for the new pane. (default: auto-derived by
+            mirroring the pane_id suffix herdr itself assigns to the new
+            pane, e.g. "<workspace-label>-p3" or "<workspace-label>-pA" --
+            never guessed/computed, so it always matches the real id)
   -n        Skip the /herdr preload step (spawn + clear trust dialog only).
   -f        Focus the new pane after creating it. (default: unfocused)
   -h        Show this help and exit.
@@ -103,11 +105,13 @@ if [ -z "$LABEL" ]; then
   # Derive the prefix from the workspace's own label (not the target pane's
   # label) so this stays correct even if panes were manually renamed.
   PREFIX=$(herdr workspace get "$WORKSPACE_ID" | jq -r '.result.workspace.label')
-  MAX_N=$(herdr pane list --workspace "$WORKSPACE_ID" | jq -r --arg p "$PREFIX" '
-    .result.panes[].label // empty
-    | select(test("^" + $p + "-p[0-9]+$"))
-    | sub("^" + $p + "-p"; "") | tonumber' | sort -n | tail -1)
-  LABEL="${PREFIX}-p$(( ${MAX_N:-0} + 1 ))"
+  # Mirror herdr's own pane_id suffix (wN:pM's pM part) verbatim, as a
+  # string -- never guessed from existing labels. Guessing via "highest
+  # existing label + 1" breaks two ways: the suffix isn't guaranteed to be
+  # a decimal integer (herdr assigns letters too, e.g. pA), and even when
+  # it is, a deleted highest-numbered pane makes the guess undercount
+  # relative to herdr's real (monotonic, never-reused) internal counter.
+  LABEL="${PREFIX}-${NEW_PANE#*:}"
 fi
 herdr pane rename "$NEW_PANE" "$LABEL" >&2
 


### PR DESCRIPTION
## What

- `herdr-init`/`herdr-spawn-agent`が付けるpane labelの番号が、herdrが実際に割り振るpane_idの数字とズレる問題を修正
- labelはherdrが実際に割り当てたpane_idのサフィックス（`wN:pM`の`pM`部分）を文字列としてそのまま転用する方式に統一（数値変換・推測は一切しない）
- 役割分担を変更: 最初に作られるpane（workspace root）＝ターミナル、そこから分割した2つ目＝hub agent（`herdr-spawn-agent`はsplit＋swapで元の見た目（hub大きく上、terminal小さく下）を維持）
- `herdr-common.sh`の`spawn_and_prime_agent`のポーリングを高速化し、`/herdr`プリロード時の未検出レース（fresh spawn直後は`idle`と報告されても実際は入力を受け付ける準備ができていない）を修正

詳細な設計はObsidianのプランを参照: `Vault/dotfiles/plans/herdr-pane-label-id-統一.md`

## Why

labelとherdrが実際に割り振るpane_idがズレると、既存の自動label採番ロジックが（非数字サフィックスやpane削除時の欠番により）壊れる問題があった。詳細はissue #38参照。

refs #38

## Test plan

- [x] `bin/herdr-init`をスクラッチディレクトリに対して実行し、`herdr pane list`でterminal/hub両方のlabel末尾サフィックスとpane_idのサフィックスが完全一致することを確認
- [x] hub agent側で`claude`が実際に起動していること、`herdr pane edges`でterminalが下・小さいpane、hubが上・大きいpaneになっていることを確認
- [x] `bin/herdr-spawn-agent`を複数回実行してworker paneを追加し、都度label/id一致を確認
- [x] worker paneを1つ閉じてから追加し、新paneのlabelサフィックスが詰め直されず、herdrが実際に払い出した新しいサフィックスと一致することを確認（欠番シミュレーション）
- [x] `bin/herdr-init -h` / `bin/herdr-spawn-agent -h`のヘルプ文言が新方式を正しく説明していることを確認
- [x] 既に信頼済みのディレクトリに対して`herdr-init`を実行し、trust-dialogポーリングがスキップされつつ`/herdr`プリロードが実際に処理される（`state_change_seq`がidle→working→idleと遷移し、pane内容にHERDR_ENVチェック結果が反映される）ことを確認
