### PR TITLE
herdr-spawn-agentにレイアウト自動判定モードを追加する

### DIFF
--- a/bin/herdr-common.sh
+++ b/bin/herdr-common.sh
@@ -83,3 +83,84 @@ spawn_and_prime_agent() {
     herdr agent wait "$pane" --until idle --timeout 15000 >&2
   fi
 }
+
+# auto_detect_split_target [PANE_ID]
+#   Inspects the current layout (via `herdr pane edges`) and decides which
+#   pane to split and in which direction to grow a 1-pane -> 2 -> 3 -> 4
+#   (2x2) layout one step at a time. Sets the caller's TARGET_PANE and
+#   DIRECTION variables on success. On any shape it doesn't recognize
+#   (including an already-complete 2x2), prints a diagnostic to stderr and
+#   returns 1 without setting either variable -- callers run under `set -e`,
+#   so a plain (unwrapped) call aborts the script.
+#
+#   PANE_ID defaults to the caller's own pane (`herdr pane current`), since
+#   this is meant to be run from inside the hub/agent pane doing the
+#   delegating.
+auto_detect_split_target() {
+  local pane="${1:-}"
+  if [ -z "$pane" ]; then
+    pane=$(herdr pane current | jq -r '.result.pane.pane_id')
+  fi
+
+  local layout
+  layout=$(herdr pane edges --pane "$pane" | jq -c '.result.edges.layout')
+
+  # The bottom terminal band spans the full width of the area and sits at
+  # the largest y -- exclude it. What's left is the "upper area" that
+  # herdr-spawn-agent actually grows.
+  local upper
+  upper=$(echo "$layout" | jq -c '
+    (.area.width) as $aw
+    | (.panes | map(select(.rect.width == $aw)) | max_by(.rect.y).pane_id) as $bottom
+    | .panes | map(select(.pane_id != $bottom))
+  ')
+
+  local count
+  count=$(echo "$upper" | jq 'length')
+
+  case "$count" in
+    1)
+      TARGET_PANE=$(echo "$upper" | jq -r '.[0].pane_id')
+      DIRECTION="down"
+      return 0
+      ;;
+    2)
+      # Vertically stacked: same x, different y. Split the top one (smaller
+      # y) to the right, growing an L-shape.
+      local xs
+      xs=$(echo "$upper" | jq '[.[].rect.x] | unique | length')
+      if [ "$xs" -eq 1 ]; then
+        TARGET_PANE=$(echo "$upper" | jq -r 'min_by(.rect.y).pane_id')
+        DIRECTION="right"
+        return 0
+      fi
+      ;;
+    3)
+      # L-shape: grouping by x gives one column of 2 (stacked) and one
+      # column of 1, and the lone pane's y lines up with the pair column's
+      # top. Split the pair column's bottom pane to the right, completing
+      # the 2x2. Grouped by x rather than assuming "left column" -- stays
+      # correct even if panes were manually rearranged left/right.
+      local shape sizes
+      shape=$(echo "$upper" | jq -c 'group_by(.rect.x) | map({panes: ., n: length})')
+      sizes=$(echo "$shape" | jq -c '[.[].n] | sort')
+      if [ "$sizes" = "[1,2]" ]; then
+        local single_y pair_min_y
+        single_y=$(echo "$shape" | jq -r '.[] | select(.n == 1) | .panes[0].rect.y')
+        pair_min_y=$(echo "$shape" | jq -r '.[] | select(.n == 2) | (.panes | min_by(.rect.y).rect.y)')
+        if [ "$single_y" = "$pair_min_y" ]; then
+          TARGET_PANE=$(echo "$shape" | jq -r '.[] | select(.n == 2) | (.panes | max_by(.rect.y).pane_id)')
+          DIRECTION="right"
+          return 0
+        fi
+      fi
+      ;;
+    4)
+      echo "auto_detect_split_target: layout already has a complete 2x2 grid -- pass <target> <right|down> explicitly to grow further" >&2
+      return 1
+      ;;
+  esac
+
+  echo "auto_detect_split_target: unrecognized pane layout ($count pane(s) in the upper area) -- pass <target> <right|down> explicitly (manually rearranged?)" >&2
+  return 1
+}

--- a/bin/herdr-init
+++ b/bin/herdr-init
@@ -73,9 +73,14 @@ ROOT_PANE=$(echo "$WS_JSON" | jq -r '.result.root_pane.pane_id')
 # small/bottom -- backwards from the final layout), then swap the two so
 # ROOT_PANE (terminal) ends up small at the bottom and the new pane (hub)
 # ends up large at the top.
+#
+# `pane swap` moves focus along with each pane's rect, always landing on
+# whichever pane_id was passed as --source-pane (verified empirically) --
+# HUB_PANE goes there (not ROOT_PANE) so focus ends up on the hub agent,
+# not the plain terminal, once the swap is done.
 HUB_PANE=$(herdr pane split "$ROOT_PANE" --direction down --ratio 0.7 --no-focus \
            | jq -r '.result.pane.pane_id')
-herdr pane swap --source-pane "$ROOT_PANE" --target-pane "$HUB_PANE" >&2
+herdr pane swap --source-pane "$HUB_PANE" --target-pane "$ROOT_PANE" >&2
 
 # Mirror herdr's own pane_id suffix (everything after the colon in wN:pM)
 # verbatim -- never parsed as a number -- so label and id always agree.

--- a/bin/herdr-spawn-agent
+++ b/bin/herdr-spawn-agent
@@ -11,13 +11,20 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: herdr-spawn-agent [-h] [-r RATIO] [-l LABEL] [-n] [-f] <target> <right|down>
+Usage: herdr-spawn-agent [-h] [-r RATIO] [-l LABEL] [-n] [-f] [-a] [<target> <right|down>]
 
 Arguments:
-  target      Pane id or label to split (e.g. dotfiles-p1). (required)
-  right|down  Which side of target the new pane appears on. (required)
+  target      Pane id or label to split (e.g. dotfiles-p1). (required
+              unless -a)
+  right|down  Which side of target the new pane appears on. (required
+              unless -a)
 
 Options:
+  -a        Auto-detect target/direction from the current layout instead of
+             taking them as arguments (grows a 1/2/3-pane upper area toward
+             a 2x2; errors out if the layout is already a complete 2x2 or
+             isn't a recognized shape). Mutually exclusive with
+             <target> <right|down>.
   -r RATIO  Size ratio, passed through to `herdr pane split --ratio`
             (sizes the pane being split, i.e. target -- the new pane gets
             the remainder).
@@ -35,8 +42,9 @@ RATIO=""
 LABEL=""
 PRIME=1
 FOCUS_FLAG="--no-focus"
+AUTO=0
 
-while getopts "r:l:nfh" OPT; do
+while getopts "r:l:nfah" OPT; do
   case "$OPT" in
     r)
       RATIO="$OPTARG"
@@ -50,6 +58,9 @@ while getopts "r:l:nfh" OPT; do
     f)
       FOCUS_FLAG="--focus"
       ;;
+    a)
+      AUTO=1
+      ;;
     h)
       usage
       exit 0
@@ -62,35 +73,44 @@ while getopts "r:l:nfh" OPT; do
 done
 shift $((OPTIND - 1))
 
-if [ $# -ne 2 ]; then
-  usage >&2
-  exit 1
-fi
-
-TARGET_REF="$1"
-DIRECTION="$2"
-
-case "$DIRECTION" in
-  right | down) ;;
-  *)
-    echo "herdr-spawn-agent: direction must be 'right' or 'down'" >&2
-    exit 1
-    ;;
-esac
-
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$SCRIPT_DIR/herdr-common.sh"
 
-# pane_ids contain a colon (e.g. w1:p1), labels don't -- same convention
-# herdr-id itself uses.
-case "$TARGET_REF" in
-  *:*)
-    TARGET_PANE="$TARGET_REF"
-    ;;
-  *)
-    TARGET_PANE=$("$SCRIPT_DIR/herdr-id" -p "$TARGET_REF")
-    ;;
-esac
+if [ "$AUTO" -eq 1 ]; then
+  if [ $# -ne 0 ]; then
+    echo "herdr-spawn-agent: -a is mutually exclusive with <target> <right|down>" >&2
+    usage >&2
+    exit 1
+  fi
+  auto_detect_split_target
+else
+  if [ $# -ne 2 ]; then
+    usage >&2
+    exit 1
+  fi
+
+  TARGET_REF="$1"
+  DIRECTION="$2"
+
+  case "$DIRECTION" in
+    right | down) ;;
+    *)
+      echo "herdr-spawn-agent: direction must be 'right' or 'down'" >&2
+      exit 1
+      ;;
+  esac
+
+  # pane_ids contain a colon (e.g. w1:p1), labels don't -- same convention
+  # herdr-id itself uses.
+  case "$TARGET_REF" in
+    *:*)
+      TARGET_PANE="$TARGET_REF"
+      ;;
+    *)
+      TARGET_PANE=$("$SCRIPT_DIR/herdr-id" -p "$TARGET_REF")
+      ;;
+  esac
+fi
 
 WORKSPACE_ID=$(herdr pane get "$TARGET_PANE" | jq -r '.result.pane.workspace_id')
 


### PR DESCRIPTION
## What

- `bin/herdr-common.sh`に新関数`auto_detect_split_target`を追加。`herdr pane edges`から取得したレイアウトを解析し、下部の全幅ターミナル帯を除外した「上部エリア」のpane数・配置から、次にsplitすべきpaneとdirectionを自動判定する（1個→down、2個の縦並び→上側をright、3個のL字→ペア列の下側をright）。2x2完成後や認識できない形状の場合はエラー終了し、明示的な指定を促す
- `bin/herdr-spawn-agent`に`-a`フラグを追加。既存の`getopts`が単一文字オプションのみを使う流儀に合わせ、`--auto`のような長いオプションは採用しない。`-a`と位置引数は排他
- `bin/herdr-init`: `herdr pane swap`が`--source-pane`に指定した方のpaneにフォーカスを移すことが実機検証で判明したため、`--source-pane`/`--target-pane`の指定順を入れ替え、セットアップ後にhub pane（ターミナルではなく）にフォーカスが当たるよう修正

## Why

hub agentが委任先paneを明示されずに「エージェントを起動して」と依頼された場合に、`~/.claude/CLAUDE.md`に書かれた手順をLLMが毎回手動でなぞる必要がなくなる（実況の冗長さ・判断ミスの余地・非効率の解消）。詳細な経緯は#39参照。

## Test plan

- [x] `bash -n bin/herdr-spawn-agent bin/herdr-common.sh` で構文チェック
- [x] scratch workspaceで`herdr-init`後、`herdr-spawn-agent -a -n`を3回連続実行し、1→2→3→4paneへの遷移（down→right→right）を実機確認
- [x] 4回目の`-a -n`実行が「2x2完成」のエラーで正しく終了し、5個目のpaneが作られないことを確認
- [x] 既存の明示形式（`herdr-spawn-agent  right/down`）が変更前と同じ挙動であること、`-a`と位置引数の同時指定がエラーになることを確認
- [x] 5pane以上の異常形状で`-a`がエラー終了することを実機確認（2/3pane時の不整合ケースはherdr側にpane移動・リサイズCLIが無く実機再現困難だったため、コードの制御フロー確認で代替）
- [x] `herdr-init`のフォーカス修正: scratch workspaceで実際にセットアップし、`herdr pane edges`の`layout.focused_pane_id`がhub paneになっていることを確認
