### PR TITLE
Obsidianスキルの追加とagent_skillsのバグ修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 agent_skills: agent-skills.txt .make/mise_install
 	@while IFS=: read -r repo skill; do \
 		[ -z "$$repo" ] && continue; \
-		npx skills add "$$repo" --skill "$$skill" -g; \
+		npx skills add "$$repo" --skill "$$skill" -g < /dev/null; \
 	done < agent-skills.txt
 
 bin: ln_bin

--- a/agent-skills.txt
+++ b/agent-skills.txt
@@ -1,1 +1,6 @@
 ogulcancelik/herdr:herdr
+kepano/obsidian-skills:obsidian-markdown
+kepano/obsidian-skills:obsidian-cli
+kepano/obsidian-skills:obsidian-bases
+kepano/obsidian-skills:json-canvas
+kepano/obsidian-skills:defuddle


### PR DESCRIPTION
## What

- `kepano/obsidian-skills`から`obsidian-markdown`・`obsidian-cli`・`obsidian-bases`・`json-canvas`・`defuddle`を`agent-skills.txt`に追加
- `make agent_skills`の`while`ループが、内側の`npx skills add`にstdinを奪われて2件目以降が実行されない不具合を修正（`npx`側の入力を`/dev/null`にリダイレクトしてループのstdinと分離）

## Why

Obsidianとの連携を強化するため、Obsidian公式に近い汎用スキル群を導入することにした。導入作業中に、`agent-skills.txt`へ複数行追加しても最初の1行しか処理されないバグが見つかり、あわせて修正した。

## Test plan

- [x] `make agent_skills`を実行し、`agent-skills.txt`の6行（`herdr`含む）全てが処理されることを確認
- [x] `~/.claude/skills/`に5つのスキルがインストールされたことを確認
