### PR TITLE
herdr-spawn-agent -a: count==1のケースをアスペクト比で判断するよう修正

### DIFF
--- a/bin/herdr-common.sh
+++ b/bin/herdr-common.sh
@@ -135,8 +135,16 @@ auto_detect_split_target() {
 
   case "$count" in
     1)
+      # A single upper pane: match the general split heuristic (wide pane ->
+      # right, narrow/tall pane -> down) instead of hardcoding a direction,
+      # so this stays consistent with how the 2/3-pane cases already reason
+      # about shape.
       TARGET_PANE=$(echo "$upper" | jq -r '.[0].pane_id')
-      DIRECTION="down"
+      if echo "$upper" | jq -e '.[0].rect | .width > .height' >/dev/null; then
+        DIRECTION="right"
+      else
+        DIRECTION="down"
+      fi
       return 0
       ;;
     2)


### PR DESCRIPTION
## What

- `auto_detect_split_target`の`count==1`（上段paneが1つだけ）のケースで、`DIRECTION`を無条件に`down`固定していたのを、`count==2`/`count==3`と同様にpaneの実際の形状（幅 vs 高さ）で判断するよう修正
- 幅 > 高さなら`right`、そうでなければ`down`

## Why

`count==1`だけがpaneの実際のアスペクト比を見ずに`down`固定になっており、`herdr`スキルの「幅広のpaneは`right`に、縦長・幅狭のpaneは`down`に」という一般原則、および`count==2`/`count==3`の既存分岐と一貫していなかった（詳細は#46参照）。

## Test plan

- [x] 実際のこのworkspaceの現在レイアウト（`dotfiles-p2`、横長）に対して`auto_detect_split_target`を実行し、`DIRECTION=right`になることを確認（split自体は実行せず判定のみ）
- [x] 合成データ（縦長のpane）で`DIRECTION=down`のままであることを確認
- [x] `herdr-spawn-agent -a`を実際にこのworkspaceで実行し、`right`方向にsplitされて新しいpane（`dotfiles-p5`）が生成されることを実地確認。確認後にpaneはclose

refs #46（リリース後の動作確認を経てから手動でクローズする）
