### PR TITLE
Issue/PRテンプレートの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,13 @@
+---
+name: General
+about: General-purpose issue template
+title: ''
+labels: ''
+assignees: ''
+---
+
+## What
+
+## Why
+
+## Open Questions

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## What
+
+## Why
+
+## Test plan


### PR DESCRIPTION
## What

`.github/ISSUE_TEMPLATE/general.md`（`## What` / `## Why` / `## Open Questions`）と`.github/pull_request_template.md`（`## What` / `## Why` / `## Test plan`）を追加。manglaneの[Issue 20](https://github.com/travail/manglane/issues/20)で決定済みの汎用テンプレートをそのまま転用。

## Why

issue/PRの書式はこれまで暗黙の慣習として各issue/PRで手動再現されていた。GitHubテンプレートとして整備することで、新規issue/PR作成時に自動で正しい見出しが差し込まれるようにする。

## Test plan

- [x] manglane側の実ファイル（`.github/ISSUE_TEMPLATE/general.md` 131バイト、`.github/pull_request_template.md` 30バイト）と、ダウンロードした内容・バイト数が完全一致することを確認
- [x] プロジェクト固有の内容（manglane固有のパス・サイト名等）が含まれていないことを確認

refs #49
