### PR TITLE
PRテンプレートにRefs見出しを追加する

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+## Refs
+
+Refs #
+
 ## What
 
 ## Why


### PR DESCRIPTION
## Refs

Refs #52

## What

`.github/pull_request_template.md`の見出しを`Refs`/`What`/`Why`/`Test plan`の4本立てに変更した。

## Why

PR #42・#44でどちらも「Why」に「Closes #N」と書いてしまった前例、そして本リポジトリでもPR #47で「Closes #46」と書きかけて直前に気づいた前例がある。issue参照を独立した見出しとして常設し、自由記述の文中に紛れ込ませないようにする。manglaneの[Issue 46](https://github.com/travail/manglane/issues/46)・[PR 47](https://github.com/travail/manglane/pull/47)と同内容。

## Test plan

- [x] 本PR自体がこのテンプレートを使って作成されており、`Refs #52`が意図通り書けることを確認
- [x] manglane側の実ファイル内容（MCP経由で取得）とバイト単位で一致することを確認
