### PR TITLE
PRのtype:ラベルを参照issueから自動同期するGitHub Actionsを追加

### DIFF
--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   sync-labels:

--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -1,0 +1,64 @@
+name: Sync PR labels from referenced issue
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Copy type: labels from referenced issues onto this PR"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const re = /\b(?:refs?|close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+
+            const issueNumbers = new Set();
+            let match;
+            while ((match = re.exec(body)) !== null) {
+              issueNumbers.add(Number(match[1]));
+            }
+
+            if (issueNumbers.size === 0) {
+              core.info('No referenced issues found in PR body.');
+              return;
+            }
+
+            const typeLabels = new Set();
+            for (const number of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                });
+                for (const label of issue.labels) {
+                  const name = typeof label === 'string' ? label : label.name;
+                  if (name && name.startsWith('type: ')) {
+                    typeLabels.add(name);
+                  }
+                }
+              } catch (error) {
+                core.warning(`Could not fetch issue #${number}: ${error.message}`);
+              }
+            }
+
+            if (typeLabels.size === 0) {
+              core.info('No type: labels found on referenced issue(s).');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: Array.from(typeLabels),
+            });
+
+            core.info(`Applied labels: ${Array.from(typeLabels).join(', ')}`);


### PR DESCRIPTION
## Refs

Refs #51

## What

`.github/workflows/sync-pr-labels.yml`を追加。`pull_request`（opened/edited/synchronize）をトリガーに、PR本文から`refs`/`close(s/d)`/`fix(es/ed)`/`resolve(s/d)` `#N`（大文字小文字問わず）を抽出し、参照している全issueの`type:`ラベルの和集合をPR自身に付与する。

`dotfiles`にとって最初のGitHub Actionsワークフローになる。

## Why

「issueと同じラベルをPRにも付ける」というルールを、人・エージェントの手動対応に頼らず機械的に保証するため。実際に[PR 50](https://github.com/travail/dotfiles/pull/50)でラベル付けを一度忘れた前例がある。

Issue 51のOpen Questionsは以下のように決定した:
- 参照キーワードは`refs`に加えGitHub標準のclose/closes/closed・fix/fixes/fixed・resolve/resolves/resolvedも対象にする
- 複数issueを参照し`type:`が割れている場合は和集合を全て付与する
- 実装は`actions/github-script`

## Test plan

- [x] ローカルでYAML構文を検証（`name:`フィールド内の`type:`という文字列がYAMLのマッピングと誤解釈される構文エラーを発見・修正）
- [x] 本PR自体が`Refs #51`を参照しており、Issue 51の`type: feature`ラベルが自動でこのPRに付与されることを実地確認（マージ前にActionsの実行結果で確認）
