### PR TITLE
HERDR_PRIMEDフラグでプライミング済みかを判定できるようにする

### DIFF
--- a/bin/herdr-common.sh
+++ b/bin/herdr-common.sh
@@ -10,7 +10,17 @@
 spawn_and_prime_agent() {
   local pane="$1" prime="${2:-1}"
 
-  herdr pane run "$pane" "claude" >&2
+  # HERDR_PRIMED=1 is a hard signal (distinct from HERDR_ENV=1, which just
+  # means "running inside a herdr-managed pane") that /herdr and /herdr-hub
+  # were actually sent to this pane by this function -- set only when we're
+  # actually about to prime (prime=1), so a caller can check it instead of
+  # assuming priming happened just because HERDR_ENV=1 is set (e.g. a pane
+  # started by running `claude` directly was never routed through here).
+  if [ "$prime" -eq 1 ]; then
+    herdr pane run "$pane" "HERDR_PRIMED=1 claude" >&2
+  else
+    herdr pane run "$pane" "claude" >&2
+  fi
 
   # herdr needs a moment to detect the freshly spawned agent -- `herdr agent
   # wait` errors immediately (no retry) if the target isn't registered yet,


### PR DESCRIPTION
## Refs

Refs #48

## What

`bin/herdr-common.sh`の`spawn_and_prime_agent`が`claude`を起動する際、`prime=1`（実際に`/herdr`・`/herdr-hub`を送る場合）に限り`HERDR_PRIMED=1 claude`として起動するよう修正した。

あわせて（dotfilesリポジトリ管理外）、グローバルCLAUDE.mdのherdrセクションを、`HERDR_ENV=1`ではなく`HERDR_PRIMED=1`をプライミング済みの判断基準とする記述に更新した。

## Why

`HERDR_ENV=1`は「herdr管理下のpaneで動いている」ことしか示さず、`spawn_and_prime_agent`経由でプライミングされたかどうかとは別。`herdr`コマンドを直接起動した場合、`HERDR_ENV=1`は立つがプライミングは行われない。

検討の過程で「新しい環境変数を増やさず、ロード済みスキルを機械的に照会できないか」という案も出たが、Claude Codeにはそのような照会API・レジストリが存在せず、確認できるのは「会話履歴の自己点検」という不確実な手段のみだと判明した。確実な信号として、新しいフラグを導入する方針とした。

## Test plan

- [x] `bash -n bin/herdr-common.sh`で構文チェック
- [x] このworkspaceで実際に`herdr-spawn-agent -a`を実行し、生成されたpane内で`echo $HERDR_PRIMED`が`1`を返すことを確認
