### PR TITLE
ラベル同期ワークフローをbug/enhancement/maintenanceに対応

### DIFF
--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -12,12 +12,16 @@ jobs:
   sync-labels:
     runs-on: ubuntu-latest
     steps:
-      - name: "Copy type: labels from referenced issues onto this PR"
+      - name: Copy category labels from referenced issues onto this PR
         uses: actions/github-script@v7
         with:
           script: |
             const body = context.payload.pull_request.body || '';
             const re = /\b(?:refs?|close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+
+            // The set of category labels this repo classifies issues/PRs
+            // with. Update this if the label scheme changes.
+            const CATEGORY_LABELS = new Set(['bug', 'enhancement', 'chore']);
 
             const issueNumbers = new Set();
             let match;
@@ -30,7 +34,7 @@ jobs:
               return;
             }
 
-            const typeLabels = new Set();
+            const categoryLabels = new Set();
             for (const number of issueNumbers) {
               try {
                 const { data: issue } = await github.rest.issues.get({
@@ -40,8 +44,8 @@ jobs:
                 });
                 for (const label of issue.labels) {
                   const name = typeof label === 'string' ? label : label.name;
-                  if (name && name.startsWith('type: ')) {
-                    typeLabels.add(name);
+                  if (name && CATEGORY_LABELS.has(name)) {
+                    categoryLabels.add(name);
                   }
                 }
               } catch (error) {
@@ -49,8 +53,8 @@ jobs:
               }
             }
 
-            if (typeLabels.size === 0) {
-              core.info('No type: labels found on referenced issue(s).');
+            if (categoryLabels.size === 0) {
+              core.info('No category labels found on referenced issue(s).');
               return;
             }
 
@@ -58,7 +62,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: Array.from(typeLabels),
+              labels: Array.from(categoryLabels),
             });
 
-            core.info(`Applied labels: ${Array.from(typeLabels).join(', ')}`);
+            core.info(`Applied labels: ${Array.from(categoryLabels).join(', ')}`);

--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -21,7 +21,7 @@ jobs:
 
             // The set of category labels this repo classifies issues/PRs
             // with. Update this if the label scheme changes.
-            const CATEGORY_LABELS = new Set(['bug', 'enhancement', 'chore']);
+            const CATEGORY_LABELS = new Set(['bug', 'enhancement', 'maintenance']);
 
             const issueNumbers = new Set();
             let match;


### PR DESCRIPTION
## Refs

N/A（issueなし、ユーザーからの直接依頼）

## What

`sync-pr-labels.yml`のカテゴリラベル判定を、`type: `接頭辞チェックから明示的な許可リストに変更した。さらに`chore`ラベル自体を`maintenance`にリネームした（GitHub上のラベルも同名にリネーム済み、紐付いていた全issue/PRの関連は自動的に引き継がれている）。

## Why

GitHub標準の`bug`/`enhancement`ラベルの方が我々が作った`type: feature`/`type: bug`より粒度が細かいため、そちらを使う方針に変更した。ラベル自体を変えただけではワークフローの`type: `接頭辞マッチが効かなくなるため、あわせて修正した。

`chore`→`maintenance`のリネームはmanglane側の決定を踏襲したもの。manglane-p2に経緯を確認したところ、「chore（雑用）という語感が、CI/ツール整備のような専門性の要る仕事を軽んじて見える」という指摘があり、代替案（ktlo/infra/tooling）を検討した末、中立的なニュアンスの`maintenance`に落ち着いたとのこと。色・説明はmanglaneの実際の値（`#d4c5f9`、"Tooling, CI, and other upkeep work not tied to a feature"）に合わせた。

## Test plan

- [x] ローカルでYAML構文を検証
- [x] マッチングロジックをNode.jsでローカル実行し、`bug`は検出・`type: feature`（旧ラベル、既に削除済み）と`duplicate`（カテゴリ外）は無視されることを確認
- [x] `chore`→`maintenance`リネーム後、全10件（issue 5・PR 5）の紐付けが維持されていることを`gh`で確認
- [ ] 本PRはissueに紐付かないため自己参照でのAction実地テストは行っていない。次に本物のissueを参照するPRを作る際に実地確認する
