### PR TITLE
Claude Codeのstatuslineにコンテキスト使用率とレートリミット残量を表示する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 PWD=$(shell pwd)
 UNAME := $(shell uname)
 
-.PHONY: all brew_bundle agent_skills bin ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_zim zim ln_aqua ln_mise ln_herdr clean_aqua clean_emacs clean cleanall
+.PHONY: all brew_bundle agent_skills bin ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_zim zim ln_aqua ln_mise ln_herdr ln_claude clean_aqua clean_emacs clean cleanall
 
-all: .make/install_packages .make/aqua_install .make/mise_install ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_mise ln_zim ln_herdr
+all: .make/install_packages .make/aqua_install .make/mise_install ln_bin ln_emacs ln_git ln_mysql ln_perltidyrc ln_tmux ln_zshrc ln_gemrc ln_perl ln_php ln_aqua ln_mise ln_zim ln_herdr ln_claude
 
 ifeq ($(UNAME), Darwin)
 .make/install_packages: Brewfile Brewfile.darwin
@@ -98,6 +98,11 @@ ln_mise: mise-config.toml
 ln_herdr: herdr-config.toml
 	mkdir -p $(HOME)/.config/herdr
 	ln -sfn $(PWD)/herdr-config.toml $(HOME)/.config/herdr/config.toml
+
+# settings.json itself stays outside this repository; only the script is linked.
+ln_claude: claude/statusline.sh
+	mkdir -p $(HOME)/.claude
+	ln -sfn $(PWD)/claude/statusline.sh $(HOME)/.claude/statusline.sh
 
 clean_aqua:
 	rm -f ~/.config/aquaproj-aqua/aqua.yaml

--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+set -euo pipefail
+#
+# Claude Code status line.
+#
+# Reads the session JSON on stdin and prints two lines:
+#   1. model, reasoning effort, current branch and repository
+#   2. context window usage, plan rate limits and session cost
+#
+# What each number on the second line measures:
+#
+#   🔋 ctx N%   How full this conversation's context window is right now.
+#               Taken against context_window_size, which is 200k by default and
+#               1M on models with extended context, and counted from input
+#               tokens only: fresh input, cache writes and cache reads. Output
+#               tokens are excluded, matching how Claude Code itself derives
+#               used_percentage. This is a level rather than a running total --
+#               /compact and /clear push it back down. Nearing 100% means
+#               auto-compaction is close.
+#
+#   ⏳ plan 5h N% / 7d N%
+#               How much of the subscription's rolling 5-hour and 7-day usage
+#               allowances is already spent. Both windows count every session
+#               inside the period, not just this one, so panes running side by
+#               side add up here. Each window frees itself at its own resets_at;
+#               at 100% that window is exhausted until it rolls over.
+#
+#   💰 $N       Estimated cost of this session in USD, computed client-side at
+#               list price. On a subscription it is a yardstick for how much
+#               work a session represents, not an amount that gets billed.
+#
+# Every percentage is "used", never "remaining", and is labelled with what it
+# measures. The leading emoji are static category markers rather than gauges,
+# so a full battery never reads as a full context window.
+#
+# Fields that Claude Code omits (rate limits before the first API response,
+# effort on models without the parameter, repo outside a git checkout) drop
+# their segment instead of printing a placeholder.
+#
+# Input schema: https://docs.claude.com/en/docs/claude-code/statusline
+
+RESET=$'\033[0m'
+DIM=$'\033[2m'
+GREEN=$'\033[32m'
+YELLOW=$'\033[33m'
+RED=$'\033[31m'
+CYAN=$'\033[36m'
+
+# Warn above this share of a window, and alert above the second threshold.
+WARN_PCT=60
+ALERT_PCT=80
+
+input=$(cat)
+
+model=""
+effort=""
+repo=""
+cwd=""
+project_dir=""
+ctx=""
+five_hour=""
+seven_day=""
+cost="0"
+
+# One jq pass emits shell assignments; @sh quotes each interpolated value.
+# Absent objects index to null in jq, so a missing .rate_limits is not an error.
+assignments=$(printf '%s' "$input" | jq -r '
+  def pct: if . == null then "" else (round | tostring) end;
+  @sh "model=\(.model.display_name // "")",
+  @sh "effort=\(.effort.level // "")",
+  @sh "repo=\(.workspace.repo.name // "")",
+  @sh "cwd=\(.workspace.current_dir // "")",
+  @sh "project_dir=\(.workspace.project_dir // "")",
+  @sh "ctx=\(.context_window.used_percentage | pct)",
+  @sh "five_hour=\(.rate_limits.five_hour.used_percentage | pct)",
+  @sh "seven_day=\(.rate_limits.seven_day.used_percentage | pct)",
+  @sh "cost=\(.cost.total_cost_usd // 0)"
+' 2>/dev/null) || assignments=""
+eval "$assignments"
+
+# The branch is the one field the JSON does not carry, so ask git directly.
+# Anchor it to the session directory: the script's own cwd is not guaranteed.
+branch=""
+if [ -n "$cwd" ]; then
+  branch=$(git -C "$cwd" branch --show-current 2>/dev/null) || branch=""
+fi
+
+if [ -z "$repo" ] && [ -n "$project_dir" ]; then
+  repo=$(basename "$project_dir")
+fi
+
+pct_color() {
+  if [ "$1" -ge "$ALERT_PCT" ]; then
+    printf '%s' "$RED"
+  elif [ "$1" -ge "$WARN_PCT" ]; then
+    printf '%s' "$YELLOW"
+  else
+    printf '%s' "$GREEN"
+  fi
+}
+
+# Line 1: what this session is.
+line1=""
+if [ -n "$model" ]; then
+  if [ -n "$effort" ]; then
+    line1="${CYAN}${model}·${effort}${RESET}"
+  else
+    line1="${CYAN}${model}${RESET}"
+  fi
+fi
+
+# The branch comes first and the separator is padded, so a double click selects
+# the branch name alone without dragging the repository name along with it.
+location=""
+if [ -n "$branch" ] && [ -n "$repo" ]; then
+  location="${branch} ${DIM}/${RESET} ${repo}"
+elif [ -n "$branch" ]; then
+  location="$branch"
+elif [ -n "$repo" ]; then
+  location="$repo"
+fi
+
+if [ -n "$location" ]; then
+  if [ -n "$line1" ]; then
+    line1="${line1}  ${location}"
+  else
+    line1="$location"
+  fi
+fi
+
+# Line 2: what this session has spent.
+segments=()
+
+if [ -n "$ctx" ]; then
+  segments+=("🔋 ctx $(pct_color "$ctx")${ctx}%${RESET}")
+fi
+
+plan=""
+if [ -n "$five_hour" ]; then
+  plan="5h $(pct_color "$five_hour")${five_hour}%${RESET}"
+fi
+if [ -n "$seven_day" ]; then
+  if [ -n "$plan" ]; then
+    plan="${plan} ${DIM}·${RESET} "
+  fi
+  plan="${plan}7d $(pct_color "$seven_day")${seven_day}%${RESET}"
+fi
+if [ -n "$plan" ]; then
+  segments+=("⏳ plan ${plan}")
+fi
+
+cost_display=$(printf '%.2f' "$cost" 2>/dev/null) || cost_display=""
+if [ -n "$cost_display" ]; then
+  segments+=("💰 \$${cost_display}")
+fi
+
+line2=""
+for segment in ${segments[@]+"${segments[@]}"}; do
+  if [ -z "$line2" ]; then
+    line2="$segment"
+  else
+    line2="${line2}  ${segment}"
+  fi
+done
+
+if [ -n "$line1" ]; then
+  printf '%s\n' "$line1"
+fi
+if [ -n "$line2" ]; then
+  printf '%s\n' "$line2"
+fi


### PR DESCRIPTION
## Refs

Refs #62

## What

Claude Code の statusline を追加しました。2 行構成です。

```
Opus·high  master / dotfiles
🔋 ctx 32%  ⏳ plan 5h 61% · 7d 42%  💰 $1.24
```

- `claude/statusline.sh` を新設。stdin の JSON を jq 一回で読み、shell 変数への代入文を生成して `eval` する（フィールドごとに jq を起動しない）
- Makefile に `ln_claude` を追加し、`.PHONY` と `all` に登録。`~/.claude/statusline.sh` へ symlink を張る
- `~/.claude/settings.json` への `statusLine` 追記は手作業。このファイルはリポジトリの管理外のため

表示上の判断は次の三点です。

- **割合はすべて「使用済み」向きに統一し、`ctx` ・ `plan` のラベルを添えた。**元記事の筆者が「その割合が残りなのか使用済みなのか読み手に伝わらない」という難点を自ら挙げていたため、絵文字は残量ゲージではなく静的なカテゴリ標識として使い、意味は数値とラベルに持たせています
- **1 行目はブランチ名を先頭に置き、`/` の前後にスペースを入れた。**ダブルクリックでブランチ名だけを選択でき、リポジトリ名まで巻き込まないようにするためです
- **取得できないフィールドは項目ごと落とす。**レートリミットは最初の API 応答まで、`effort` は非対応モデルで、`workspace.repo` は git 管理外で、それぞれ欠落します。プレースホルダは出しません

閾値による色分け（60% 以上で黄、80% 以上で赤）も入れています。これは Issue の仕様には書いていない追加分です。

各アイコンが何を分母に取り何を数えているかは、スクリプト冒頭のコメントに記載しました。とくに `plan` の値がそのセッション単体ではなく、同一期間内の全セッションの合算である点は、複数ペインを並べる運用で誤読しやすいため明示しています。

## Why

きっかけは https://zenn.dev/kawarimidoll/articles/d3f1a7542de71a の「statuslineにトークン使用割合を出す」です。

コンテキスト窓の埋まり具合とプラン枠の消費率は、いずれも画面から読み取る手段がありませんでした。とくに herdr で複数ペインを並べる運用では、プラン枠が全ペインの合算で減るため、体感と実際がずれます。

「残りのトークン量」には意味の異なる二つがあります。コンテキスト窓の残りは次のコンパクトまでの余裕であり、レートリミット枠の残りはその日あと何時間作業できるかです。両方を別々のラベルで出しています。

## Test plan

- [x] 4 パターンの入力で出力を確認。いずれも exit 0
  - 全フィールド揃った入力
  - `rate_limits` ・ `effort` ・ `workspace.repo` が欠落し `used_percentage` が null の入力（該当項目が消える）
  - 高使用率の入力（色が赤・黄に変わる）
  - 空の stdin と JSON として壊れた stdin（落ちずにコスト行のみ出力）
- [x] `bash -n` による構文チェック
- [x] `make -n ln_claude` で内容を確認したうえで `make ln_claude` を実行し、symlink の生成を確認
- [x] `jq -e '.statusLine'` で `settings.json` が有効な JSON のままであることを確認
- [x] 実セッションで有効化済み。表示の見え方は動作中の環境で確認
- [x] 実行コストを計測。1 回あたり約 29ms （内訳は jq が約 16ms 、git が約 5ms 、残りが bash の起動と fork ）。API トークンの消費はゼロ（statusline はローカル実行のため）
- [ ] `shellcheck` は未導入のため未実施（ #16 で対応予定）

更新頻度も実測しました。1 通のメッセージにツール呼び出しを 3 つ載せても更新は 3 回にはならず、更新の単位はツールの実行回数ではなくアシスタントのメッセージであることを確認しています（300ms のデバウンスあり）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
