### PR TITLE
statuslineのレートリミット表示にリセットまでの残り時間を併記する

### DIFF
--- a/claude/statusline.sh
+++ b/claude/statusline.sh
@@ -18,12 +18,27 @@ set -euo pipefail
 #               /compact and /clear push it back down. Nearing 100% means
 #               auto-compaction is close.
 #
-#   5h N% / 7d N%
+#   5h N% (2h13m) / 7d N% (3d11h20m)
 #               How much of the subscription's rolling 5-hour and 7-day usage
 #               allowances is already spent. Both windows count every session
 #               inside the period, not just this one, so panes running side by
 #               side add up here. Each window frees itself at its own resets_at;
 #               at 100% that window is exhausted until it rolls over.
+#
+#               The time in parentheses is how long that rollover is away,
+#               derived from resets_at against the current clock. It is relative
+#               and never an absolute time of day: what a full window costs is
+#               the wait, not the hour it ends. Claude Code drops a window from
+#               the JSON once it has rolled over, so a negative remainder should
+#               not arise, but the boundary is clamped to zero regardless.
+#
+#               A remainder counts down between messages, so the status line
+#               needs to re-run while the session sits idle. That is what
+#               refreshInterval in the statusLine settings is for. The used
+#               percentages cannot be kept fresh the same way -- they only
+#               change when Claude Code hands over new JSON -- but a remainder
+#               is a fixed instant minus the clock, so recomputing it locally
+#               is enough.
 #
 #   $N          Estimated cost of this session in USD, computed client-side at
 #               list price. On a subscription it is a yardstick for how much
@@ -62,13 +77,16 @@ cwd=""
 project_dir=""
 ctx=""
 five_hour=""
+five_hour_resets=""
 seven_day=""
+seven_day_resets=""
 cost="0"
 
 # One jq pass emits shell assignments; @sh quotes each interpolated value.
 # Absent objects index to null in jq, so a missing .rate_limits is not an error.
 assignments=$(printf '%s' "$input" | jq -r '
   def pct: if . == null then "" else (round | tostring) end;
+  def epoch: if type == "number" then (floor | tostring) else "" end;
   @sh "model=\(.model.display_name // "")",
   @sh "effort=\(.effort.level // "")",
   @sh "repo=\(.workspace.repo.name // "")",
@@ -76,7 +94,9 @@ assignments=$(printf '%s' "$input" | jq -r '
   @sh "project_dir=\(.workspace.project_dir // "")",
   @sh "ctx=\(.context_window.used_percentage | pct)",
   @sh "five_hour=\(.rate_limits.five_hour.used_percentage | pct)",
+  @sh "five_hour_resets=\(.rate_limits.five_hour.resets_at | epoch)",
   @sh "seven_day=\(.rate_limits.seven_day.used_percentage | pct)",
+  @sh "seven_day_resets=\(.rate_limits.seven_day.resets_at | epoch)",
   @sh "cost=\(.cost.total_cost_usd // 0)"
 ' 2>/dev/null) || assignments=""
 eval "$assignments"
@@ -91,6 +111,34 @@ fi
 if [ -z "$repo" ] && [ -n "$project_dir" ]; then
   repo=$(basename "$project_dir")
 fi
+
+# How long until the given epoch second, as "3d11h20m", "2h13m" or "6m".
+# Larger units are dropped once they are zero, so a five-hour window never
+# prints a leading "0d". Under a minute reads as "<1m" rather than rounding to
+# zero, which would look like a window that has already rolled over; an instant
+# already past clamps to "0m".
+remaining_time() {
+  local target=$1 now=$2 rest days hours minutes
+  rest=$((target - now))
+  if [ "$rest" -le 0 ]; then
+    printf '0m'
+    return
+  fi
+  if [ "$rest" -lt 60 ]; then
+    printf '<1m'
+    return
+  fi
+  days=$((rest / 86400))
+  hours=$((rest % 86400 / 3600))
+  minutes=$((rest % 3600 / 60))
+  if [ "$days" -gt 0 ]; then
+    printf '%dd%dh%dm' "$days" "$hours" "$minutes"
+  elif [ "$hours" -gt 0 ]; then
+    printf '%dh%dm' "$hours" "$minutes"
+  else
+    printf '%dm' "$minutes"
+  fi
+}
 
 pct_color() {
   if [ "$1" -ge "$ALERT_PCT" ]; then
@@ -138,15 +186,23 @@ if [ -n "$ctx" ]; then
   segments+=("ctx $(pct_color "$ctx")${ctx}%${RESET}")
 fi
 
+now=$(date +%s)
+
 plan=""
 if [ -n "$five_hour" ]; then
   plan="5h $(pct_color "$five_hour")${five_hour}%${RESET}"
+  if [ -n "$five_hour_resets" ]; then
+    plan="${plan} ${DIM}($(remaining_time "$five_hour_resets" "$now"))${RESET}"
+  fi
 fi
 if [ -n "$seven_day" ]; then
   if [ -n "$plan" ]; then
     plan="${plan} ${DIM}·${RESET} "
   fi
   plan="${plan}7d $(pct_color "$seven_day")${seven_day}%${RESET}"
+  if [ -n "$seven_day_resets" ]; then
+    plan="${plan} ${DIM}($(remaining_time "$seven_day_resets" "$now"))${RESET}"
+  fi
 fi
 if [ -n "$plan" ]; then
   segments+=("$plan")


### PR DESCRIPTION
## Refs

Refs #64

## What

statusline の 5 時間枠・ 7 日枠の使用率に、その枠がリセットされるまでの残り時間を併記する。

変更前:

```
ctx 32%  5h 61% · 7d 42%  $1.24
```

変更後:

```
ctx 32%  5h 61% (2h13m) · 7d 42% (3d11h20m)  $1.24
```

- `claude/statusline.sh` の jq に `rate_limits.*.resets_at` を追加した。数値でなければ空文字に落とすため、フィールドが欠けていても従来どおり併記が消えるだけで済む
- `remaining_time()` を追加した。粒度は分までで、上位の単位が 0 なら落とす（ `3d11h20m` ・ `2h13m` ・ `6m` ）。 1 分未満は `<1m` 、 `resets_at` を過ぎていれば `0m` にクランプする
- 残り時間は `DIM` の括弧で出す。使用率の色分け（ 60% 以上で黄、 80% 以上で赤）は変更していないので、主役はパーセントのまま

あわせて `~/.claude/settings.json` の `statusLine` に `"refreshInterval": 60` を追加した（このファイルはリポジトリの管理外のため、本 PR の差分には含まれない）。

## Why

使用率だけでは「あとどれだけ待てば回復するか」が分からない。枠が 90% まで埋まっているとき、リセットが 10 分後なのか 3 時間後なのかで取るべき行動が変わる。

絶対時刻ではなく相対の残り時間を出す。枠が埋まったときに問題になるのは待ち時間そのものであって、終わる時刻を出すと読み手が現在時刻との引き算をして待ち時間に戻す手間が要る。

`refreshInterval` が要るのは、残り時間が時間とともに変化するのに対し、 statusline はアシスタントのメッセージが届いたときにしか実行されないため。分まで表示する以上、間隔は 60 秒にする。アイドル中もスクリプトが走るが、 1 回あたり約 29ms のため 1 日あたり約 42 秒の CPU 時間であり、許容する。

この点は使用率とは事情が逆になる。使用率は Claude Code が渡す JSON 自体が古いままなので `refreshInterval` では救えないが、残り時間は `resets_at` という固定値と現在時刻からローカルに再計算できるため、新しいデータが来なくても正しい値になる。

## Test plan

サンプル JSON を流し込んで、以下を bash 3.2 上で確認済み。

- `resets_at` が 30 秒後・ 300000 秒後 → `5h 61% (<1m) · 7d 42% (3d11h20m)`
- `resets_at` が 400 秒後・ 8000 秒後 → `5h 61% (6m) · 7d 42% (2h13m)`
- `resets_at` が 50 秒前・現在ちょうど → いずれも `(0m)` にクランプされ、負の値が出ない
- `resets_at` が欠落した場合、併記だけが消えて `5h 61% · 7d 42%` になる
- `rate_limits` ごと欠落した場合・ stdin が JSON でない場合は、従来どおり該当セグメントを落として正常終了する

実セッションで無操作のまま表示が更新されることの確認は、新しいセッションを開始してから行う。
